### PR TITLE
Fix: Correct GitHub Actions workflow and remove dummy script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web-buddy"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run build script
+        run: bash build.sh


### PR DESCRIPTION
This commit corrects two issues:

1. Updates the GitHub Actions workflow (`.github/workflows/ci.yml`) to correctly point to the `build.sh` script in the root directory.
2. Removes an unnecessary dummy script from the `scripts` section of `web-buddy/package.json`.