### PR TITLE
Fix(ci): Set up Node.js in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+          cache-dependency-path: web-buddy/package-lock.json
+
       - name: Run build script
         run: bash build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           cache: 'npm'
           cache-dependency-path: web-buddy/package-lock.json
 


### PR DESCRIPTION
Adds a step to the GitHub Actions workflow to set up Node.js 18.x. This makes npm and npx available in the runner environment, which is necessary for the build.sh script to install dependencies (npm ci) and run the Next.js build (next build) for the web-buddy application.

This should resolve the "next: not found" error previously encountered during the build process. It also includes caching for npm dependencies based on the web-buddy/package-lock.json file to speed up future builds.