### PR TITLE
feat: Add Playwright tests and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,59 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web-buddy
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'npm'
           cache-dependency-path: web-buddy/package-lock.json
 
-      - name: Run build script
-        run: bash build.sh
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Next.js application
+        run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
+
+      - name: Start Next.js application
+        run: npm run start &
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
+
+      - name: Wait for application to start
+        run: |
+          timeout 30s bash -c 'until curl -sSf http://localhost:3000 > /dev/null; do echo "Waiting for app to start..."; sleep 1; done'
+          curl -I http://localhost:3000
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
+
+      - name: Upload Playwright report if tests fail
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web-buddy/playwright-report/
+          retention-days: 30
+
+      - name: Upload Playwright traces if tests fail
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: web-buddy/test-results/
+          retention-days: 30

--- a/web-buddy/package-lock.json
+++ b/web-buddy/package-lock.json
@@ -16,12 +16,14 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.45.3",
         "@tailwindcss/postcss": "^4.1.8",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
+        "playwright": "^1.45.3",
         "tailwindcss": "^4.1.8",
         "typescript": "^5"
       }
@@ -958,6 +960,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "devOptional": true,
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3335,6 +3352,20 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5000,6 +5031,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "devOptional": true,
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "devOptional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web-buddy/package.json
+++ b/web-buddy/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "framer-motion": "^12.16.0",
@@ -25,6 +26,8 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4.1.8",
-    "typescript": "^5"
+    "typescript": "^5",
+    "playwright": "^1.45.3",
+    "@playwright/test": "^1.45.3"
   }
 }

--- a/web-buddy/playwright.config.ts
+++ b/web-buddy/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/web-buddy/tests/example.spec.ts
+++ b/web-buddy/tests/example.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('should have the correct title', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Procrastination Buddy/);
+});
+
+test('should navigate to the about page', async ({ page }) => {
+  await page.goto('/');
+  await page.click('text=About');
+  await expect(page).toHaveURL('/about');
+  await expect(page.locator('h1')).toHaveText('About Procrastination Buddy');
+});


### PR DESCRIPTION
This commit introduces Playwright for end-to-end testing of the Next.js application.

Key changes:
- Added Playwright and @playwright/test as dev dependencies.
- Created a Playwright configuration file (`web-buddy/playwright.config.ts`) configured to use only Chromium.
- Added example Playwright tests for basic site functionality.
- Updated the GitHub Actions CI workflow (`.github/workflows/ci.yml`):
    - Installs Playwright Chromium browser.
    - Builds the Next.js application.
    - Starts the application locally.
    - Runs Playwright tests against the local server using only Chromium.
    - Uploads Playwright HTML report and traces as artifacts if tests fail.
- Added an npm script (`test:e2e`) to `web-buddy/package.json` for running tests locally.

CI workflow comments have been removed and browser installation simplified as per your feedback.