### PR TITLE
feat: Add canonical tag to all pages

### DIFF
--- a/web-buddy/src/app/layout.tsx
+++ b/web-buddy/src/app/layout.tsx
@@ -10,6 +10,10 @@ const inter = Inter({
 export const metadata = {
   title: "nobuddy",
   description: "A growing collection of experimental tools with personality",
+  metadataBase: new URL("https://nobuddy.org"),
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
This change adds a canonical tag to all pages in the website. This is achieved by adding `metadataBase` and `alternates: { canonical: "/" }` to the `metadata` object in `web-buddy/src/app/layout.tsx`.

The canonical URL is set to https://nobuddy.org.