### PR TITLE
test: add e2e coverage for tool routes and homepage content

### DIFF
--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("homepage hero and manifesto content", () => {
+  test("renders the terminal intro hero", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("h1")).toHaveText("Creative Tools for Nerds");
+    await expect(
+      page.getByRole("link", { name: "Follow Nobuddyorg on GitHub" })
+    ).toBeVisible();
+  });
+
+  test("terminal intro plays the script lines", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByText("You’ve reached The Buddy Compendium.")
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("renders the manifesto sections", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: "Software can be useful and weird" })
+    ).toBeAttached();
+    await expect(
+      page.getByRole("heading", { name: "This is a hobby project" })
+    ).toBeAttached();
+    await expect(
+      page.getByRole("link", { name: "Launch /tools →" })
+    ).toBeAttached();
+  });
+});

--- a/web-buddy/tests/tools-routes.spec.ts
+++ b/web-buddy/tests/tools-routes.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+const readyTools = tools.filter((tool) => tool.status === "ready");
+
+// Each ready tool page always renders a "Tech Stack" section; "Screenshots"
+// is only present for tools whose client component defines one.
+const sectionsWithoutScreenshots = new Set(["gamegallerybuddy"]);
+
+for (const tool of readyTools) {
+  test.describe(`/tools/${tool.slug}`, () => {
+    test(`renders ${tool.name} heading and key sections`, async ({
+      page,
+    }) => {
+      await page.goto(`/tools/${tool.slug}`);
+
+      await expect(page.locator("h1")).toHaveText(tool.name);
+      await expect(
+        page.getByRole("heading", { name: "Tech Stack" })
+      ).toBeVisible();
+
+      if (!sectionsWithoutScreenshots.has(tool.slug)) {
+        await expect(
+          page.getByRole("heading", { name: "Screenshots" })
+        ).toBeVisible();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- 4 of 5 tool detail routes (`thrashbuddy`, `gamegallerybuddy`, `collectionbuddy`, `ridemergebuddy`) and all homepage hero/manifesto content had zero e2e coverage; a runtime error in any of those client components would render a blank page in production while CI stayed green.
- Adds `tests/tools-routes.spec.ts`, a parameterized spec iterating the `ready` entries of `tools.ts`, asserting each `/tools/<slug>` renders its h1 and key sections (Tech Stack / Screenshots where present).
- Adds `tests/homepage.spec.ts` covering the terminal intro hero and manifesto sections.

Closes #389

## Test plan
- [x] `npm run build` (static export)
- [x] `npx serve out -l 3000` + `npx playwright test` — 15/15 passing
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)