### PR TITLE
fix: add branded 404 page with navigation back to the site

### DIFF
--- a/web-buddy/src/app/not-found.tsx
+++ b/web-buddy/src/app/not-found.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+
+export const metadata: Metadata = {
+  title: "Page Not Found - nobuddy.org",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function NotFound() {
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen flex flex-col items-center justify-center text-center px-4 md:px-6 pt-20 md:pt-32 pb-28">
+        <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+          404
+        </h1>
+        <p className="max-w-xl text-lg sm:text-xl text-gray-700 dark:text-gray-300 mb-8">
+          This page doesn&apos;t exist, or has wandered off somewhere.
+        </p>
+        <div className="flex flex-wrap gap-4 justify-center">
+          <a
+            href="/"
+            className="bg-black dark:bg-white text-white dark:text-black font-semibold px-8 py-3 rounded-full shadow-lg hover:bg-gray-900 dark:hover:bg-gray-100 transition"
+            title="home"
+          >
+            Back to Home
+          </a>
+          <a
+            href="/tools"
+            className="border border-gray-400 dark:border-gray-600 text-black dark:text-white font-semibold px-8 py-3 rounded-full hover:bg-gray-100 dark:hover:bg-zinc-900 transition"
+            title="tools"
+          >
+            Browse the Tools
+          </a>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/web-buddy/tests/not-found.spec.ts
+++ b/web-buddy/tests/not-found.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("404 page", () => {
+  test("renders branded navigation for an unknown URL", async ({ page }) => {
+    const response = await page.goto("/this-page-does-not-exist");
+
+    expect(response?.status()).toBe(404);
+    await expect(page.locator("h1")).toHaveText("404");
+    await expect(
+      page.getByRole("link", { name: "Back to Home" })
+    ).toHaveAttribute("href", "/");
+    await expect(
+      page.getByRole("link", { name: "Browse the Tools" })
+    ).toHaveAttribute("href", "/tools");
+  });
+});


### PR DESCRIPTION
## Summary
- `src/app/not-found.tsx` didn't exist, so the static export shipped Next's bare default 404 (no header, footer, or links) for every unknown path on nobuddy.org.
- Adds a branded `not-found.tsx` reusing `Header`/`Footer` with links back to `/` and `/tools`, marked `noindex, nofollow`.

Closes #390

## Test plan
- [x] `npm run build` — emits `out/404.html` from the new page
- [x] `npx serve out -l 3000` — confirmed unknown paths return HTTP 404 and render the branded page
- [x] `npx playwright test` — 16/16 passing (new `tests/not-found.spec.ts`)
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)