### PR TITLE
fix: respect prefers-reduced-motion across site-wide animations

### DIFF
--- a/web-buddy/src/app/components/EmojiBackground.tsx
+++ b/web-buddy/src/app/components/EmojiBackground.tsx
@@ -79,10 +79,14 @@ export default function EmojiGridCanvas() {
       }
     };
 
-    const draw = () => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    const draw = (animate: boolean) => {
       resizeCanvasIfNeeded();
 
-      const t = Date.now();
+      const t = animate ? Date.now() : 0;
       const { width, height } = canvas;
 
       ctx.clearRect(0, 0, width, height);
@@ -91,20 +95,26 @@ export default function EmojiGridCanvas() {
       ctx.textBaseline = "middle";
 
       for (const p of particlesRef.current.values()) {
-        const offset = Math.sin(t * p.speed + p.phase) * p.floatRange;
+        const offset = animate
+          ? Math.sin(t * p.speed + p.phase) * p.floatRange
+          : 0;
         const x = p.baseX + cellSize / 2 + offset;
         const y = p.baseY + cellSize / 2 - offset;
         ctx.fillText(p.emoji, x, y);
       }
 
-      rafRef.current = requestAnimationFrame(draw);
+      if (animate) rafRef.current = requestAnimationFrame(() => draw(true));
     };
 
-    draw();
-    window.addEventListener("resize", resizeCanvasIfNeeded);
+    const handleResize = prefersReducedMotion
+      ? () => draw(false)
+      : resizeCanvasIfNeeded;
+
+    draw(!prefersReducedMotion);
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("resize", resizeCanvasIfNeeded);
+      window.removeEventListener("resize", handleResize);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
   }, []);

--- a/web-buddy/src/app/components/MotionProvider.tsx
+++ b/web-buddy/src/app/components/MotionProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+export default function MotionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -177,7 +177,7 @@ export default function TerminalIntro() {
           ))}
           {phase === "wait" && (
             <motion.div
-              className="mt-8 text-yellow-400 animate-pulse"
+              className="mt-8 text-yellow-400 animate-pulse motion-reduce:animate-none"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
             >

--- a/web-buddy/src/app/layout.tsx
+++ b/web-buddy/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Inter } from "next/font/google";
 import EmojiBackground from "./components/EmojiBackground";
+import MotionProvider from "./components/MotionProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -16,9 +17,11 @@ export default function RootLayout({
     <html lang="en" className={inter.variable}>
       <body className="relative overflow-x-hidden">
         <EmojiBackground />
-        <div className="relative">
-          <div className="relative z-10">{children}</div>
-        </div>
+        <MotionProvider>
+          <div className="relative">
+            <div className="relative z-10">{children}</div>
+          </div>
+        </MotionProvider>
       </body>
     </html>
   );

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -32,7 +32,7 @@ export default function HomePage() {
     <>
       <PageWrapper metadata={metadata} jsonLd={jsonLd} />
       <Header />
-      <main className="h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth text-black dark:text-white overflow-x-hidden">
+      <main className="h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth motion-reduce:scroll-auto text-black dark:text-white overflow-x-hidden">
         <section className="snap-start min-h-screen">
           <CirclesBackground variant="page2" />
           <TerminalIntro />

--- a/web-buddy/tests/reduced-motion.spec.ts
+++ b/web-buddy/tests/reduced-motion.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("prefers-reduced-motion", () => {
+  test("emoji background canvas is static", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    const canvas = page.locator("canvas");
+    await expect(canvas).toBeAttached();
+
+    const frameAt = () =>
+      page.evaluate(() => {
+        const el = document.querySelector("canvas");
+        return el?.toDataURL();
+      });
+
+    const first = await frameAt();
+    await page.waitForTimeout(500);
+    const second = await frameAt();
+
+    expect(first).toBe(second);
+  });
+
+  test("terminal intro pulse animation is disabled", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    const pulse = page.getByText("Scroll down to continue...");
+    await expect(pulse).toBeVisible({ timeout: 15000 });
+    await expect(pulse).toHaveCSS("animation-name", "none");
+  });
+
+  test("homepage scroll container uses auto scroll behavior", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    const scrollBehavior = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      return main ? getComputedStyle(main).scrollBehavior : null;
+    });
+
+    expect(scrollBehavior).toBe("auto");
+  });
+});


### PR DESCRIPTION
## Summary
- The emoji canvas ran an unbounded `requestAnimationFrame` loop, the terminal prompt pulsed forever, and the homepage forced smooth snap-scrolling — none of it respected the OS `prefers-reduced-motion` preference (WCAG 2.2.2 Pause, Stop, Hide).
- `EmojiBackground` now checks `prefers-reduced-motion` and renders a static frame (no rAF loop) instead.
- `TerminalIntro`'s `animate-pulse` and the homepage's `scroll-smooth` gain `motion-reduce:` Tailwind variants.
- New `MotionProvider` wraps the app in framer-motion's `<MotionConfig reducedMotion="user">` so `whileInView`/`animate` motion across tool pages (screenshots, tech stack) and the manifesto sections also respects the preference.

Closes #391

## Test plan
- [x] `npm run build`
- [x] `npx serve out -l 3000` + `npx playwright test` — 19/19 passing, including new `tests/reduced-motion.spec.ts` using `page.emulateMedia({ reducedMotion: "reduce" })`
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)