### PR TITLE
refactor: extract shared metadata/JSON-LD builder for tool pages

### DIFF
--- a/web-buddy/src/app/tools/collectionbuddy/page.tsx
+++ b/web-buddy/src/app/tools/collectionbuddy/page.tsx
@@ -1,42 +1,12 @@
-import { SITE_URL, AUTHOR_NAME } from "../../globals";
-import { createMetadata } from "../../metadata";
-import { tools } from "../tools";
+import { getToolPageData } from "../toolPage";
 import CollectionBuddyClient from "./client";
 import PageWrapper from "../../components/PageWrapper";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const slug = "collectionbuddy";
-const path = `/tools/${slug}`;
+const { title, metadata, jsonLd } = getToolPageData("collectionbuddy");
 
-const tool = tools.find((t) => t.slug === slug);
-
-const title = tool?.name ?? "";
-const titleFull = `${title} - A tool to organize and track your collected items`;
-const description = tool?.description ?? "";
-const image = tool?.previewImage;
-const url = `${SITE_URL}${path}`;
-const authorName = AUTHOR_NAME;
-
-export const metadata = createMetadata({
-  title: titleFull,
-  description,
-  slug: path,
-  image,
-});
-
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: title,
-  description,
-  url,
-  author: {
-    "@type": "Person",
-    name: authorName,
-  },
-  ...(image ? { image: image } : {}),
-};
+export { metadata };
 
 export default function CollectionBuddyPage() {
   return (

--- a/web-buddy/src/app/tools/gamegallerybuddy/page.tsx
+++ b/web-buddy/src/app/tools/gamegallerybuddy/page.tsx
@@ -1,42 +1,12 @@
-import { SITE_URL, AUTHOR_NAME } from "../../globals";
-import { createMetadata } from "../../metadata";
-import { tools } from "../tools";
+import { getToolPageData } from "../toolPage";
 import GameGalleryBuddyClient from "./client";
 import PageWrapper from "../../components/PageWrapper";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const slug = "gamegallerybuddy";
-const path = `/tools/${slug}`;
+const { title, metadata, jsonLd } = getToolPageData("gamegallerybuddy");
 
-const tool = tools.find((t) => t.slug === slug);
-
-const title = tool?.name ?? "";
-const titleFull = `${title} - A spring boot app for managing game galleries`;
-const description = tool?.description ?? "";
-const image = tool?.previewImage;
-const url = `${SITE_URL}${path}`;
-const authorName = AUTHOR_NAME;
-
-export const metadata = createMetadata({
-  title: titleFull,
-  description,
-  slug: path,
-  image,
-});
-
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: titleFull,
-  description,
-  url,
-  author: {
-    "@type": "Person",
-    name: authorName,
-  },
-  ...(image ? { image } : {}),
-};
+export { metadata };
 
 export default function GameGalleryBuddyPage() {
   return (

--- a/web-buddy/src/app/tools/procrastinationbuddy/page.tsx
+++ b/web-buddy/src/app/tools/procrastinationbuddy/page.tsx
@@ -1,42 +1,12 @@
-import { SITE_URL, AUTHOR_NAME } from "../../globals";
-import { createMetadata } from "../../metadata";
-import { tools } from "../tools";
+import { getToolPageData } from "../toolPage";
 import ProcrastinationBuddyClient from "./client";
 import PageWrapper from "../../components/PageWrapper";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const slug = "procrastinationbuddy";
-const path = `/tools/${slug}`;
+const { title, metadata, jsonLd } = getToolPageData("procrastinationbuddy");
 
-const tool = tools.find((t) => t.slug === slug);
-
-const title = tool?.name ?? "";
-const titleFull = `${title} - A tool to help you embrace procrastination`;
-const description = tool?.description ?? "";
-const image = tool?.previewImage;
-const url = `${SITE_URL}${path}`;
-const authorName = AUTHOR_NAME;
-
-export const metadata = createMetadata({
-  title: titleFull,
-  description,
-  slug: path,
-  image,
-});
-
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: title,
-  description,
-  url,
-  author: {
-    "@type": "Person",
-    name: authorName,
-  },
-  ...(image ? { image: image } : {}),
-};
+export { metadata };
 
 export default function ProcrastinationBuddyPage() {
   return (

--- a/web-buddy/src/app/tools/ridemergebuddy/page.tsx
+++ b/web-buddy/src/app/tools/ridemergebuddy/page.tsx
@@ -1,42 +1,12 @@
-import { SITE_URL, AUTHOR_NAME } from "../../globals";
-import { createMetadata } from "../../metadata";
-import { tools } from "../tools";
+import { getToolPageData } from "../toolPage";
 import RideMergeBuddyClient from "./client";
 import PageWrapper from "../../components/PageWrapper";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const slug = "ridemergebuddy";
-const path = `/tools/${slug}`;
+const { title, metadata, jsonLd } = getToolPageData("ridemergebuddy");
 
-const tool = tools.find((t) => t.slug === slug);
-
-const title = tool?.name ?? "RideMergeBuddy";
-const titleFull = `${title} - View and merge your Strava activities`;
-const description = tool?.description ?? "Manage, merge, and analyze your Strava activities in one place.";
-const image = tool?.previewImage;
-const url = `${SITE_URL}${path}`;
-const authorName = AUTHOR_NAME;
-
-export const metadata = createMetadata({
-  title: titleFull,
-  description,
-  slug: path,
-  image,
-});
-
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: title,
-  description,
-  url,
-  author: {
-    "@type": "Person",
-    name: authorName,
-  },
-  ...(image ? { image: image } : {}),
-};
+export { metadata };
 
 export default function RideMergeBuddyPage() {
   return (

--- a/web-buddy/src/app/tools/thrashbuddy/page.tsx
+++ b/web-buddy/src/app/tools/thrashbuddy/page.tsx
@@ -1,42 +1,12 @@
-import { SITE_URL, AUTHOR_NAME } from "../../globals";
-import { createMetadata } from "../../metadata";
-import { tools } from "../tools";
+import { getToolPageData } from "../toolPage";
 import ThrashBuddyClient from "./client";
 import PageWrapper from "../../components/PageWrapper";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const slug = "thrashbuddy";
-const path = `/tools/${slug}`;
+const { title, metadata, jsonLd } = getToolPageData("thrashbuddy");
 
-const tool = tools.find((t) => t.slug === slug);
-
-const title = tool?.name ?? "";
-const titleFull = `${title} - A tool to push your web api/app to it's limits with load and performance testing`;
-const description = tool?.description ?? "";
-const image = tool?.previewImage;
-const url = `${SITE_URL}${path}`;
-const authorName = AUTHOR_NAME;
-
-export const metadata = createMetadata({
-  title: titleFull,
-  description,
-  slug: path,
-  image,
-});
-
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: title,
-  description,
-  url,
-  author: {
-    "@type": "Person",
-    name: authorName,
-  },
-  ...(image ? { image: image } : {}),
-};
+export { metadata };
 
 export default function ThrashBuddyPage() {
   return (

--- a/web-buddy/src/app/tools/toolPage.ts
+++ b/web-buddy/src/app/tools/toolPage.ts
@@ -1,0 +1,36 @@
+import { SITE_URL, AUTHOR_NAME } from "../globals";
+import { createMetadata } from "../metadata";
+import { tools } from "./tools";
+
+export function getToolPageData(slug: string) {
+  const tool = tools.find((t) => t.slug === slug);
+  const path = `/tools/${slug}`;
+  const url = `${SITE_URL}${path}`;
+
+  const title = tool?.name ?? "";
+  const description = tool?.description ?? "";
+  const image = tool?.previewImage;
+  const titleFull = tool?.tagline ? `${title} - ${tool.tagline}` : title;
+
+  const metadata = createMetadata({
+    title: titleFull,
+    description,
+    slug: path,
+    image,
+  });
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: title,
+    description,
+    url,
+    author: {
+      "@type": "Person",
+      name: AUTHOR_NAME,
+    },
+    ...(image ? { image } : {}),
+  };
+
+  return { title, metadata, jsonLd };
+}

--- a/web-buddy/src/app/tools/tools.ts
+++ b/web-buddy/src/app/tools/tools.ts
@@ -4,6 +4,7 @@ export const tools = [
   {
     slug: "procrastinationbuddy",
     name: "Procrastination Buddy",
+    tagline: "A tool to help you embrace procrastination",
     description:
       "Avoid productivity with delightfully useless tasks. Built using Streamlit, Ollama AI, and Docker. Perfect for professional procrastinators.",
     logo: "/logos/procrastination.webp",
@@ -15,6 +16,8 @@ export const tools = [
   {
     slug: "thrashbuddy",
     name: "Thrash Buddy",
+    tagline:
+      "A tool to push your web api/app to it's limits with load and performance testing",
     description:
       "Load-test your apps at scale using k6, Grafana, Prometheus, and AWS EKS. Fully cloud-native and containerized with Docker and Helm.",
     logo: "/logos/thrash.webp",
@@ -26,6 +29,7 @@ export const tools = [
   {
     slug: "gamegallerybuddy",
     name: "Game Gallery Buddy",
+    tagline: "A spring boot app for managing game galleries",
     description:
       "Generates a wallpaper using all board games from a BoardGameGeek user's collection. Customizable layout with many options.",
     logo: "/logos/gamegallery.webp",
@@ -44,6 +48,7 @@ export const tools = [
   {
     slug: "collectionbuddy",
     name: "Collection Buddy",
+    tagline: "A tool to organize and track your collected items",
     description:
       "A web-app catalog for your collected items. Organize and track stamps, coins, or any collectibles with an elegant interface.",
     logo: "/logos/collection.webp",
@@ -82,6 +87,7 @@ export const tools = [
   {
     slug: "ridemergebuddy",
     name: "Ride Merge Buddy",
+    tagline: "View and merge your Strava activities",
     description:
       "Merge GPX tracks from multiple cycling sessions. Ideal for Strava users, activity aggregators, and route cleanup enthusiasts.",
     logo: "/logos/ridemerge.webp",

--- a/web-buddy/tests/tools-metadata.spec.ts
+++ b/web-buddy/tests/tools-metadata.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+const readyTools = tools.filter((tool) => tool.status === "ready");
+
+for (const tool of readyTools) {
+  test(`/tools/${tool.slug} emits consistent metadata and JSON-LD shape`, async ({
+    page,
+  }) => {
+    await page.goto(`/tools/${tool.slug}`);
+
+    await expect(page).toHaveTitle(
+      new RegExp(`^${tool.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} - `)
+    );
+
+    const jsonLd = await page
+      .locator('script[type="application/ld+json"]')
+      .first()
+      .textContent();
+    const parsed = JSON.parse(jsonLd ?? "{}");
+
+    expect(parsed["@context"]).toBe("https://schema.org");
+    expect(parsed["@type"]).toBe("SoftwareApplication");
+    expect(parsed.name).toBe(tool.name);
+    expect(parsed.description).toBe(tool.description);
+    expect(parsed.author).toEqual({ "@type": "Person", name: "nobuddy" });
+  });
+}


### PR DESCRIPTION
## Summary
- The five `tools/*/page.tsx` files were 86-90% identical copy-paste boilerplate that had already drifted: `gamegallerybuddy` used `name: titleFull` in its JSON-LD instead of `name: title`, `ridemergebuddy` carried non-empty fallback strings the other four didn't, and every page duplicated the same metadata/JSON-LD construction plus a pointless `authorName` alias.
- Adds a `tagline` field to each ready tool in `tools.ts` and a shared `getToolPageData(slug)` helper (`toolPage.ts`) that builds `metadata` and `jsonLd` from it.
- Each `page.tsx` now shrinks to ~18 lines with a single source of truth for the JSON-LD shape, fixing the drift (all five now consistently use `name: title`, no invented fallback text).

Closes #392

## Test plan
- [x] `npm run build`
- [x] `npx serve out -l 3000` + `npx playwright test` — 24/24 passing, including new `tests/tools-metadata.spec.ts` asserting all five tool pages emit identical-shape metadata/JSON-LD from the shared helper
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)