### PR TITLE
refactor: extract shared TechStack, Screenshots, AnimatedPreview, and page shell components

### DIFF
--- a/web-buddy/src/app/components/ToolAnimatedPreview.tsx
+++ b/web-buddy/src/app/components/ToolAnimatedPreview.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { motion } from "framer-motion";
+import AnimatedClip from "./AnimatedClip";
+
+export default function ToolAnimatedPreview({
+  src,
+  poster,
+  label,
+}: {
+  src: string;
+  poster: string;
+  label: string;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8 }}
+      className="mb-12 rounded-xl overflow-hidden shadow-lg"
+    >
+      <AnimatedClip
+        src={src}
+        poster={poster}
+        label={label}
+        className="w-full h-auto rounded-xl"
+      />
+    </motion.div>
+  );
+}

--- a/web-buddy/src/app/components/ToolPageShell.tsx
+++ b/web-buddy/src/app/components/ToolPageShell.tsx
@@ -1,0 +1,18 @@
+export default function ToolPageShell({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
+      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
+        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
+          {title}
+        </h1>
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/web-buddy/src/app/components/ToolScreenshots.tsx
+++ b/web-buddy/src/app/components/ToolScreenshots.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Image from "next/image";
+import { motion } from "framer-motion";
+import AnimatedClip from "./AnimatedClip";
+
+export interface ToolScreenshot {
+  src: string;
+  alt: string;
+  text: string;
+}
+
+export default function ToolScreenshots({
+  screenshots,
+  imageDir,
+  media,
+}: {
+  screenshots: ToolScreenshot[];
+  imageDir: string;
+  media: "image" | "video";
+}) {
+  return (
+    <section className="mt-20 space-y-16">
+      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
+        Screenshots
+      </h2>
+
+      {screenshots.map(({ src, alt, text }, index) => {
+        const isEven = index % 2 === 0;
+        return (
+          <motion.div
+            key={alt}
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true }}
+            className={`flex flex-col md:flex-row ${
+              !isEven ? "md:flex-row-reverse" : ""
+            } items-center gap-8`}
+          >
+            {media === "image" ? (
+              <Image
+                src={`${imageDir}/${src}`}
+                alt={alt}
+                width={300}
+                height={200}
+                className="rounded-xl shadow-md w-full md:w-1/2"
+              />
+            ) : (
+              <AnimatedClip
+                src={`${imageDir}/${src}.mp4`}
+                poster={`${imageDir}/${src}-poster.jpg`}
+                label={alt}
+                className="rounded-xl shadow-md w-full md:w-1/2"
+              />
+            )}
+            <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
+              <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
+                {alt}
+              </h3>
+              <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                {text}
+              </p>
+            </div>
+          </motion.div>
+        );
+      })}
+    </section>
+  );
+}

--- a/web-buddy/src/app/components/ToolTechStack.tsx
+++ b/web-buddy/src/app/components/ToolTechStack.tsx
@@ -1,0 +1,29 @@
+export interface TechStackItem {
+  name: string;
+  url: string;
+}
+
+export default function ToolTechStack({ items }: { items: TechStackItem[] }) {
+  return (
+    <section className="mt-20">
+      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
+        Tech Stack
+      </h2>
+      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
+        {items.map(({ name, url }) => (
+          <li key={name}>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-black dark:hover:text-white"
+              title={name}
+            >
+              {name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web-buddy/src/app/tools/collectionbuddy/client.tsx
+++ b/web-buddy/src/app/tools/collectionbuddy/client.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { motion } from "framer-motion";
-import AnimatedClip from "../../components/AnimatedClip";
+import ToolPageShell from "../../components/ToolPageShell";
+import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
+import ToolScreenshots, {
+  ToolScreenshot,
+} from "../../components/ToolScreenshots";
+import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
 
-const screenshots = [
+const imageDir = "/images/collection-buddy";
+
+const screenshots: ToolScreenshot[] = [
   {
     src: "login",
     alt: "Secure Authentication",
@@ -26,65 +32,25 @@ const screenshots = [
   },
 ];
 
-function AnimatedPreview() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-      className="mb-12 rounded-xl overflow-hidden shadow-lg"
-    >
-      <AnimatedClip
-        src="/images/collection-buddy/preview.mp4"
-        poster="/images/collection-buddy/preview-poster.jpg"
-        label="Collection Buddy animated preview"
-        className="w-full h-auto rounded-xl"
-      />
-    </motion.div>
-  );
-}
-
-function TechStackSection() {
-  const techStack = [
-    { name: "Next.js", url: "https://nextjs.org/" },
-    { name: "React", url: "https://reactjs.org/" },
-    { name: "TypeScript", url: "https://www.typescriptlang.org/" },
-    { name: "Tailwind CSS", url: "https://tailwindcss.com/" },
-    { name: "Framer Motion", url: "https://www.framer.com/motion/" },
-    { name: "Supabase", url: "https://supabase.com/" },
-    { name: "PostgreSQL", url: "https://www.postgresql.org/" },
-    { name: "Authentication", url: "https://supabase.com/docs/guides/auth" },
-    { name: "Storage", url: "https://supabase.com/docs/guides/storage" },
-    { name: "Static Site", url: "https://nextjs.org/docs/advanced-features/static-html-export" },
-    { name: "GitHub Pages", url: "https://pages.github.com/" },
-    { name: "Collections", url: "https://en.wikipedia.org/wiki/Collecting" },
-    { name: "PWA", url: "https://web.dev/progressive-web-apps/" },
-    { name: "Open Street Map", url: "https://www.openstreetmap.org/" }
-  ];
-
-  return (
-    <section className="mt-20">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Tech Stack
-      </h2>
-      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
-        {techStack.map(({ name, url }) => (
-          <li key={name}>
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title={name}
-            >
-              {name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+const techStack: TechStackItem[] = [
+  { name: "Next.js", url: "https://nextjs.org/" },
+  { name: "React", url: "https://reactjs.org/" },
+  { name: "TypeScript", url: "https://www.typescriptlang.org/" },
+  { name: "Tailwind CSS", url: "https://tailwindcss.com/" },
+  { name: "Framer Motion", url: "https://www.framer.com/motion/" },
+  { name: "Supabase", url: "https://supabase.com/" },
+  { name: "PostgreSQL", url: "https://www.postgresql.org/" },
+  { name: "Authentication", url: "https://supabase.com/docs/guides/auth" },
+  { name: "Storage", url: "https://supabase.com/docs/guides/storage" },
+  {
+    name: "Static Site",
+    url: "https://nextjs.org/docs/advanced-features/static-html-export",
+  },
+  { name: "GitHub Pages", url: "https://pages.github.com/" },
+  { name: "Collections", url: "https://en.wikipedia.org/wiki/Collecting" },
+  { name: "PWA", url: "https://web.dev/progressive-web-apps/" },
+  { name: "Open Street Map", url: "https://www.openstreetmap.org/" },
+];
 
 function DescriptionSection() {
   return (
@@ -112,45 +78,6 @@ function DescriptionSection() {
   );
 }
 
-function ScreenshotsSection() {
-  return (
-    <section className="mt-20 space-y-16">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Screenshots
-      </h2>
-
-      {screenshots.map(({ src, alt, text }, index) => {
-        const isEven = index % 2 === 0;
-        return (
-          <motion.div
-            key={alt}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-            className={`flex flex-col md:flex-row ${
-              !isEven ? "md:flex-row-reverse" : ""
-            } items-center gap-8`}
-          >
-            <AnimatedClip
-              src={`/images/collection-buddy/${src}.mp4`}
-              poster={`/images/collection-buddy/${src}-poster.jpg`}
-              label={alt}
-              className="rounded-xl shadow-md w-full md:w-1/2"
-            />
-            <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
-              <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
-                {alt}
-              </h3>
-              <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">{text}</p>
-            </div>
-          </motion.div>
-        );
-      })}
-    </section>
-  );
-}
-
 interface CollectionBuddyClientProps {
   title: string;
 }
@@ -159,16 +86,19 @@ export default function CollectionBuddyClient({
   title,
 }: CollectionBuddyClientProps) {
   return (
-    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
-      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
-        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
-          {title}
-        </h1>
-        <AnimatedPreview />
-        <DescriptionSection />
-        <ScreenshotsSection />
-        <TechStackSection />
-      </div>
-    </main>
+    <ToolPageShell title={title}>
+      <ToolAnimatedPreview
+        src={`${imageDir}/preview.mp4`}
+        poster={`${imageDir}/preview-poster.jpg`}
+        label="Collection Buddy animated preview"
+      />
+      <DescriptionSection />
+      <ToolScreenshots
+        screenshots={screenshots}
+        imageDir={imageDir}
+        media="video"
+      />
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
   );
 }

--- a/web-buddy/src/app/tools/gamegallerybuddy/client.tsx
+++ b/web-buddy/src/app/tools/gamegallerybuddy/client.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import { motion } from "framer-motion";
+import ToolPageShell from "../../components/ToolPageShell";
+import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
 
 const preview = {
   src: "/images/gamegallery-buddy/preview.webp",
@@ -9,94 +11,63 @@ const preview = {
   text: "GameGalleryBuddy creates a beautiful wallpaper using all board games from your BoardGameGeek collection. Just enter your BGG username and enjoy a personalized background!",
 };
 
-function TechStackSection() {
-  const techStack = [
-    { name: "BoardGameGeek", url: "https://boardgamegeek.com/" },
-    { name: "Groovy", url: "https://groovy-lang.org/" },
-    { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
-    { name: "Gradle", url: "https://gradle.org/" },
-  ];
-
-  return (
-    <section className="mt-20">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Tech Stack
-      </h2>
-      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
-        {techStack.map(({ name, url }) => (
-          <li key={name}>
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title={name}
-            >
-              {name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+const techStack: TechStackItem[] = [
+  { name: "BoardGameGeek", url: "https://boardgamegeek.com/" },
+  { name: "Groovy", url: "https://groovy-lang.org/" },
+  { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
+  { name: "Gradle", url: "https://gradle.org/" },
+];
 
 export default function GameGalleryBuddyClient({ title }: { title: string }) {
   return (
-    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
-      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
-        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
-          {title}
-        </h1>
+    <ToolPageShell title={title}>
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+        className="mb-12 rounded-xl overflow-hidden shadow-lg"
+      >
+        <Image
+          src={preview.src}
+          alt={preview.alt}
+          width={1200}
+          height={600}
+          className="w-full h-auto rounded-xl"
+        />
+      </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          className="mb-12 rounded-xl overflow-hidden shadow-lg"
-        >
-          <Image
-            src={preview.src}
-            alt={preview.alt}
-            width={1200}
-            height={600}
-            className="w-full h-auto rounded-xl"
-          />
-        </motion.div>
-
-        <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300 space-y-4">
-          <p>
-            <strong>Game Gallery Buddy</strong> turns your board game collection
-            into a wallpaper. Just enter your BoardGameGeek username and
-            customize the layout: choose cover size, show or hide names, shuffle
-            the order, and more.
-          </p>
-          <p>
-            Requires a tiny bit of dev experience to run locally, but everything
-            is explained in the README file.
-          </p>
-          <Image
-            src={`/images/gamegallery-buddy/powered-by-bgg.webp`}
-            alt="powered by bgg"
-            width={1200}
-            height={352}
-            className="w-full h-auto rounded-xl"
-          />
-          <p>
-            🔗{" "}
-            <a
-              href="https://github.com/nobuddyorg/GameGalleryBuddy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title="game gallery github"
-            >
-              View the code on GitHub or run it locally
-            </a>
-          </p>
-        </section>
-        <TechStackSection />
-      </div>
-    </main>
+      <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300 space-y-4">
+        <p>
+          <strong>Game Gallery Buddy</strong> turns your board game collection
+          into a wallpaper. Just enter your BoardGameGeek username and
+          customize the layout: choose cover size, show or hide names, shuffle
+          the order, and more.
+        </p>
+        <p>
+          Requires a tiny bit of dev experience to run locally, but everything
+          is explained in the README file.
+        </p>
+        <Image
+          src={`/images/gamegallery-buddy/powered-by-bgg.webp`}
+          alt="powered by bgg"
+          width={1200}
+          height={352}
+          className="w-full h-auto rounded-xl"
+        />
+        <p>
+          🔗{" "}
+          <a
+            href="https://github.com/nobuddyorg/GameGalleryBuddy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-black dark:hover:text-white"
+            title="game gallery github"
+          >
+            View the code on GitHub or run it locally
+          </a>
+        </p>
+      </section>
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
   );
 }

--- a/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
+++ b/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import Image from "next/image";
-import { motion } from "framer-motion";
-import AnimatedClip from "../../components/AnimatedClip";
+import ToolPageShell from "../../components/ToolPageShell";
+import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
+import ToolScreenshots, {
+  ToolScreenshot,
+} from "../../components/ToolScreenshots";
+import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
 
-const screenshots = [
+const imageDir = "/images/procrastination-buddy";
+
+const screenshots: ToolScreenshot[] = [
   {
     src: "frontend-light.webp",
     alt: "Frontend Light",
@@ -27,64 +32,21 @@ const screenshots = [
   },
 ];
 
-function AnimatedPreview() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-      className="mb-12 rounded-xl overflow-hidden shadow-lg"
-    >
-      <AnimatedClip
-        src="/images/procrastination-buddy/buddy-preview.mp4"
-        poster="/images/procrastination-buddy/buddy-preview-poster.jpg"
-        label="Procrastination Buddy animated preview"
-        className="w-full h-auto rounded-xl"
-      />
-    </motion.div>
-  );
-}
-
-function TechStackSection() {
-  const techStack = [
-    { name: "Ollama", url: "https://ollama.com/" },
-    {
-      name: "AI",
-      url: "https://en.wikipedia.org/wiki/Artificial_intelligence",
-    },
-    { name: "Streamlit", url: "https://streamlit.io/" },
-    { name: "Flask", url: "https://flask.palletsprojects.com/" },
-    { name: "Python", url: "https://www.python.org/" },
-    { name: "Docker", url: "https://www.docker.com/" },
-    { name: "Docker Compose", url: "https://docs.docker.com/compose/" },
-    { name: "PostgreSQL", url: "https://www.postgresql.org/" },
-    { name: "Ruff", url: "https://docs.astral.sh/ruff/" },
-    { name: "uv", url: "https://github.com/astral-sh/uv" },
-  ];
-
-  return (
-    <section className="mt-20">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Tech Stack
-      </h2>
-      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
-        {techStack.map(({ name, url }) => (
-          <li key={name}>
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title={name}
-            >
-              {name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+const techStack: TechStackItem[] = [
+  { name: "Ollama", url: "https://ollama.com/" },
+  {
+    name: "AI",
+    url: "https://en.wikipedia.org/wiki/Artificial_intelligence",
+  },
+  { name: "Streamlit", url: "https://streamlit.io/" },
+  { name: "Flask", url: "https://flask.palletsprojects.com/" },
+  { name: "Python", url: "https://www.python.org/" },
+  { name: "Docker", url: "https://www.docker.com/" },
+  { name: "Docker Compose", url: "https://docs.docker.com/compose/" },
+  { name: "PostgreSQL", url: "https://www.postgresql.org/" },
+  { name: "Ruff", url: "https://docs.astral.sh/ruff/" },
+  { name: "uv", url: "https://github.com/astral-sh/uv" },
+];
 
 function DescriptionSection() {
   return (
@@ -115,48 +77,6 @@ function DescriptionSection() {
   );
 }
 
-function ScreenshotsSection() {
-  return (
-    <section className="mt-20 space-y-16">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Screenshots
-      </h2>
-
-      {screenshots.map(({ src, alt, text }, index) => {
-        const isEven = index % 2 === 0;
-        return (
-          <motion.div
-            key={alt}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-            className={`flex flex-col md:flex-row ${
-              !isEven ? "md:flex-row-reverse" : ""
-            } items-center gap-8`}
-          >
-            <Image
-              src={`/images/procrastination-buddy/${src}`}
-              alt={alt}
-              width={300}
-              height={200}
-              className="rounded-xl shadow-md w-full md:w-1/2"
-            />
-            <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
-              <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
-                {alt}
-              </h3>
-              <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-                {text}
-              </p>
-            </div>
-          </motion.div>
-        );
-      })}
-    </section>
-  );
-}
-
 interface ProcrastinationBuddyClientProps {
   title: string;
 }
@@ -165,16 +85,19 @@ export default function ProcrastinationBuddyClient({
   title,
 }: ProcrastinationBuddyClientProps) {
   return (
-    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
-      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
-        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
-          {title}
-        </h1>
-        <AnimatedPreview />
-        <DescriptionSection />
-        <ScreenshotsSection />
-        <TechStackSection />
-      </div>
-    </main>
+    <ToolPageShell title={title}>
+      <ToolAnimatedPreview
+        src={`${imageDir}/buddy-preview.mp4`}
+        poster={`${imageDir}/buddy-preview-poster.jpg`}
+        label="Procrastination Buddy animated preview"
+      />
+      <DescriptionSection />
+      <ToolScreenshots
+        screenshots={screenshots}
+        imageDir={imageDir}
+        media="image"
+      />
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
   );
 }

--- a/web-buddy/src/app/tools/ridemergebuddy/client.tsx
+++ b/web-buddy/src/app/tools/ridemergebuddy/client.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { motion } from "framer-motion";
-import AnimatedClip from "../../components/AnimatedClip";
+import ToolPageShell from "../../components/ToolPageShell";
+import ToolScreenshots, {
+  ToolScreenshot,
+} from "../../components/ToolScreenshots";
+import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
 
-const screenshots = [
+const imageDir = "/images/ridemerge-buddy";
+
+const screenshots: ToolScreenshot[] = [
   {
     src: "login",
     alt: "Strava Login",
@@ -21,39 +26,14 @@ const screenshots = [
   },
 ];
 
-function TechStackSection() {
-  const techStack = [
-    { name: "Angular", url: "https://angular.io/" },
-    { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
-    { name: "Groovy", url: "https://groovy-lang.org/" },
-    { name: "Strava API", url: "https://developers.strava.com/" },
-    { name: "Google Maps API", url: "https://developers.google.com/maps" },
-    { name: "Gradle", url: "https://gradle.org/" },
-  ];
-
-  return (
-    <section className="mt-20">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Tech Stack
-      </h2>
-      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
-        {techStack.map(({ name, url }) => (
-          <li key={name}>
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title={name}
-            >
-              {name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+const techStack: TechStackItem[] = [
+  { name: "Angular", url: "https://angular.io/" },
+  { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
+  { name: "Groovy", url: "https://groovy-lang.org/" },
+  { name: "Strava API", url: "https://developers.strava.com/" },
+  { name: "Google Maps API", url: "https://developers.google.com/maps" },
+  { name: "Gradle", url: "https://gradle.org/" },
+];
 
 function DescriptionSection() {
   return (
@@ -78,45 +58,6 @@ function DescriptionSection() {
   );
 }
 
-function ScreenshotsSection() {
-  return (
-    <section className="mt-20 space-y-16">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Screenshots
-      </h2>
-
-      {screenshots.map(({ src, alt, text }, index) => {
-        const isEven = index % 2 === 0;
-        return (
-          <motion.div
-            key={alt}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-            className={`flex flex-col md:flex-row ${
-              !isEven ? "md:flex-row-reverse" : ""
-            } items-center gap-8`}
-          >
-            <AnimatedClip
-              src={`/images/ridemerge-buddy/${src}.mp4`}
-              poster={`/images/ridemerge-buddy/${src}-poster.jpg`}
-              label={alt}
-              className="rounded-xl shadow-md w-full md:w-1/2"
-            />
-            <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
-              <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
-                {alt}
-              </h3>
-              <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">{text}</p>
-            </div>
-          </motion.div>
-        );
-      })}
-    </section>
-  );
-}
-
 interface RideMergeBuddyClientProps {
   title: string;
 }
@@ -125,15 +66,14 @@ export default function RideMergeBuddyClient({
   title,
 }: RideMergeBuddyClientProps) {
   return (
-    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
-      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
-        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
-          {title}
-        </h1>
-        <DescriptionSection />
-        <ScreenshotsSection />
-        <TechStackSection />
-      </div>
-    </main>
+    <ToolPageShell title={title}>
+      <DescriptionSection />
+      <ToolScreenshots
+        screenshots={screenshots}
+        imageDir={imageDir}
+        media="video"
+      />
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
   );
 }

--- a/web-buddy/src/app/tools/thrashbuddy/client.tsx
+++ b/web-buddy/src/app/tools/thrashbuddy/client.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import Image from "next/image";
-import { motion } from "framer-motion";
-import AnimatedClip from "../../components/AnimatedClip";
+import ToolPageShell from "../../components/ToolPageShell";
+import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
+import ToolScreenshots, {
+  ToolScreenshot,
+} from "../../components/ToolScreenshots";
+import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
 
-const screenshots = [
+const imageDir = "/images/thrash-buddy";
+
+const screenshots: ToolScreenshot[] = [
   {
     src: "frontend.webp",
     alt: "Easy Usage",
@@ -27,64 +32,21 @@ const screenshots = [
   },
 ];
 
-function AnimatedPreview() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-      className="mb-12 rounded-xl overflow-hidden shadow-lg"
-    >
-      <AnimatedClip
-        src="/images/thrash-buddy/preview.mp4"
-        poster="/images/thrash-buddy/preview-poster.jpg"
-        label="Thrash Buddy animated preview"
-        className="w-full h-auto rounded-xl"
-      />
-    </motion.div>
-  );
-}
-
-function TechStackSection() {
-  const techStack = [
-    { name: "Groovy", url: "https://groovy-lang.org/" },
-    { name: "k6", url: "https://k6.io/" },
-    { name: "Grafana", url: "https://grafana.com/" },
-    { name: "Prometheus", url: "https://prometheus.io/" },
-    { name: "Testing", url: "https://en.wikipedia.org/wiki/Software_testing" },
-    { name: "DevOps", url: "https://en.wikipedia.org/wiki/DevOps" },
-    { name: "Cloud", url: "https://en.wikipedia.org/wiki/Cloud_computing" },
-    { name: "Kubernetes", url: "https://kubernetes.io/" },
-    { name: "Helm", url: "https://helm.sh/" },
-    { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
-    { name: "Gradle", url: "https://gradle.org/" },
-    { name: "Docker", url: "https://www.docker.com/" },
-    { name: "Minikube", url: "https://minikube.sigs.k8s.io/" },
-  ];
-
-  return (
-    <section className="mt-20">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Tech Stack
-      </h2>
-      <ul className="flex flex-wrap justify-center gap-4 text-sm text-gray-700 dark:text-gray-300">
-        {techStack.map(({ name, url }) => (
-          <li key={name}>
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dark:hover:text-white"
-              title={name}
-            >
-              {name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
+const techStack: TechStackItem[] = [
+  { name: "Groovy", url: "https://groovy-lang.org/" },
+  { name: "k6", url: "https://k6.io/" },
+  { name: "Grafana", url: "https://grafana.com/" },
+  { name: "Prometheus", url: "https://prometheus.io/" },
+  { name: "Testing", url: "https://en.wikipedia.org/wiki/Software_testing" },
+  { name: "DevOps", url: "https://en.wikipedia.org/wiki/DevOps" },
+  { name: "Cloud", url: "https://en.wikipedia.org/wiki/Cloud_computing" },
+  { name: "Kubernetes", url: "https://kubernetes.io/" },
+  { name: "Helm", url: "https://helm.sh/" },
+  { name: "Spring Boot", url: "https://spring.io/projects/spring-boot" },
+  { name: "Gradle", url: "https://gradle.org/" },
+  { name: "Docker", url: "https://www.docker.com/" },
+  { name: "Minikube", url: "https://minikube.sigs.k8s.io/" },
+];
 
 function DescriptionSection() {
   return (
@@ -112,46 +74,6 @@ function DescriptionSection() {
   );
 }
 
-function ScreenshotsSection() {
-  return (
-    <section className="mt-20 space-y-16">
-      <h2 className="text-2xl font-bold text-black dark:text-white mb-6 text-center">
-        Screenshots
-      </h2>
-
-      {screenshots.map(({ src, alt, text }, index) => {
-        const isEven = index % 2 === 0;
-        return (
-          <motion.div
-            key={alt}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-            className={`flex flex-col md:flex-row ${
-              !isEven ? "md:flex-row-reverse" : ""
-            } items-center gap-8`}
-          >
-            <Image
-              src={`/images/thrash-buddy/${src}`}
-              alt={alt}
-              width={300}
-              height={200}
-              className="rounded-xl shadow-md w-full md:w-1/2"
-            />
-            <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
-              <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
-                {alt}
-              </h3>
-              <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">{text}</p>
-            </div>
-          </motion.div>
-        );
-      })}
-    </section>
-  );
-}
-
 interface ThrashBuddyClientProps {
   title: string;
 }
@@ -160,16 +82,19 @@ export default function ThrashBuddyClient({
   title,
 }: ThrashBuddyClientProps) {
   return (
-    <main className="min-h-screen pt-36 pb-28 px-4 sm:px-6">
-      <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
-        <h1 className="text-4xl font-extrabold text-black dark:text-white mb-10 text-center">
-          {title}
-        </h1>
-        <AnimatedPreview />
-        <DescriptionSection />
-        <ScreenshotsSection />
-        <TechStackSection />
-      </div>
-    </main>
+    <ToolPageShell title={title}>
+      <ToolAnimatedPreview
+        src="/images/thrash-buddy/preview.mp4"
+        poster="/images/thrash-buddy/preview-poster.jpg"
+        label="Thrash Buddy animated preview"
+      />
+      <DescriptionSection />
+      <ToolScreenshots
+        screenshots={screenshots}
+        imageDir={imageDir}
+        media="image"
+      />
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
   );
 }


### PR DESCRIPTION
## Summary
- `TechStackSection` was byte-identical across all five tool `client.tsx` files (only the data array differed); `ScreenshotsSection` and the page shell were duplicated with only cosmetic differences (~150 duplicated lines total per the issue); whitespace-only drift had already crept into `procrastinationbuddy`.
- Extracts `ToolPageShell`, `ToolTechStack`, `ToolAnimatedPreview`, and `ToolScreenshots` (supporting both the `Image`-based and `AnimatedClip` video-based screenshot variants actually used across tools) into `components/`.
- Each `client.tsx` now shrinks to its data plus a bespoke `DescriptionSection`. `gamegallerybuddy`'s preview/description markup is genuinely different from the other four (static image, no screenshots gallery), so it only adopts the shared shell and tech stack list rather than being forced into the shared preview/screenshots components.

Closes #393

## Test plan
- [x] `npm run build`
- [x] Diffed the built static export for all 5 tool routes before/after the refactor — identical markup modulo build-hash chunk filenames
- [x] `npx serve out -l 3000` + `npx playwright test` — 24/24 passing (twice, incl. single-worker run to rule out flakiness)
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)