### PR TITLE
security: require human review for Dependabot major version bumps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,10 +13,20 @@ permissions:
 jobs:
     auto-approve-merge:
         runs-on: ubuntu-latest
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
 
         steps:
-            - name: Merge PR if Dependabot is the creator
-              if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+            - name: Fetch Dependabot metadata
+              id: metadata
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            # Major version bumps can carry breaking changes, so they are
+            # left for a human to review and merge manually. Patch/minor
+            # bumps auto-merge once the required CI check passes.
+            - name: Auto-merge patch and minor updates
+              if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |


### PR DESCRIPTION
## Summary
- Every Dependabot PR, including major version bumps, auto-merged the moment the required `build_and_test` check passed (`required_approving_review_count` is 0 on `main`), giving zero human checkpoints before a compromised or breaking dependency update built and deployed to production.
- Gates auto-merge on `dependabot/fetch-metadata`'s `update-type` output: semver-patch/minor bumps continue to auto-merge as before; semver-major bumps are left for a human to review and merge manually.
- Repo's cooldown (`.github/dependabot.yml`, added in #451) already covers the "freshly published version" angle; this PR covers the "no human review" angle from the same issue.

Note: branch protection's `required_approving_review_count: 0` is a repo setting, not something this PR changes — flagging in case that's also wanted, but didn't want to touch org/repo security settings without a separate explicit go-ahead.

Closes #394

## Test plan
- [x] `prek run` (zizmor) on the changed workflow — passed
- [x] Verified the pinned commit SHA (`dependabot/fetch-metadata@25dd0e34f...`) resolves to `v3.1.0` and confirmed the `update-type` output name/values against the action's `action.yml`
- [x] Not independently testable end-to-end without a live Dependabot PR; reasoned through both branches (major vs. non-major) of the new conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)