### PR TITLE
fix: render JSON-LD server-side so it ships in the static export

### DIFF
--- a/web-buddy/src/app/components/PageWrapper.tsx
+++ b/web-buddy/src/app/components/PageWrapper.tsx
@@ -1,4 +1,3 @@
-import Script from "next/script";
 import type { Metadata } from "next";
 
 interface PageWrapperProps {
@@ -6,25 +5,11 @@ interface PageWrapperProps {
   jsonLd: object;
 }
 
-export default function PageWrapper({ metadata, jsonLd }: PageWrapperProps) {
-  const rawTitle = metadata.title ?? "page";
-
-  const titleString =
-    typeof rawTitle === "string"
-      ? rawTitle
-      : Array.isArray(rawTitle)
-      ? rawTitle.join(" ")
-      : String(rawTitle);
-
-  const id = `${titleString.toLowerCase().replace(/\s+/g, "-")}-jsonld`;
-
+export default function PageWrapper({ jsonLd }: PageWrapperProps) {
   return (
-    <>
-      <Script
-        id={id}
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-    </>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
   );
 }

--- a/web-buddy/tests/jsonld.spec.ts
+++ b/web-buddy/tests/jsonld.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+const readyTools = tools.filter((tool) => tool.status === "ready");
+const paths = ["/", "/tools", "/about", ...readyTools.map((t) => `/tools/${t.slug}`)];
+
+for (const path of paths) {
+  test(`${path} ships JSON-LD in the raw (unhydrated) HTML`, async ({
+    request,
+    baseURL,
+  }) => {
+    const response = await request.get(`${baseURL}${path}`);
+    const html = await response.text();
+
+    expect(html).toContain('type="application/ld+json"');
+
+    const match = html.match(
+      /<script type="application\/ld\+json">(.*?)<\/script>/
+    );
+    expect(match).not.toBeNull();
+
+    const parsed = JSON.parse(match![1]);
+    expect(parsed["@context"]).toBe("https://schema.org");
+  });
+}


### PR DESCRIPTION
## Summary
- `PageWrapper` used `next/script`'s default `afterInteractive` strategy, which renders `null` server-side and only injects the `<script>` tag client-side after hydration. On this `output: "export"` site, no WebSite/SoftwareApplication JSON-LD ever reached the served HTML — verified live on nobuddy.org and reproduced locally in the built `out/` before this fix.
- Replaces `next/script` with a plain `<script type="application/ld+json" dangerouslySetInnerHTML={...} />` in the server component, matching Next's own JSON-LD docs.
- This also moots the secondary id-collision bug described in the issue: the removed `id` was derived from the page title, so `/` and `/tools` (identical titles) generated the same `Script` id, and `next/script`'s `LoadCache` would skip injecting the second page's JSON-LD during client-side navigation.
- `PageWrapper`'s `metadata` prop is now unused internally (kept in the interface to avoid touching all 8 call sites); removing it entirely is filed separately as #444.

Closes #395

## Test plan
- [x] `npm run build` then grepped the raw `out/*.html` files — every page (`/`, `/tools`, `/about`, all 5 tool routes) now has its own `<script type="application/ld+json">` with correct content in the unhydrated HTML
- [x] New `tests/jsonld.spec.ts` uses Playwright's raw `request` fixture (no browser/JS execution) to assert each page's HTTP response body contains valid JSON-LD
- [x] `npx serve out -l 3000` + `npx playwright test` — 32/32 passing
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)