### PR TITLE
fix: treat blank previewImage as missing in createMetadata

### DIFF
--- a/web-buddy/src/app/metadata.tsx
+++ b/web-buddy/src/app/metadata.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import { SITE_URL, SITE_NAME, AUTHOR_NAME } from "./globals";
 
+const DEFAULT_IMAGE = "/nobuddy_logo_preview.webp";
+
 export function createMetadata({
   title,
   description,
   slug = "",
-  image = "/nobuddy_logo_preview.webp",
+  image = DEFAULT_IMAGE,
 }: {
   title: string;
   description: string;
@@ -14,9 +16,10 @@ export function createMetadata({
 }): Metadata {
   const url = `${SITE_URL}${slug}`;
   const fullTitle = `${title} - crafted with love and fun by ${AUTHOR_NAME}`;
-  const absoluteImage = image.startsWith("http")
-    ? image
-    : `${SITE_URL}${image}`;
+  const resolvedImage = image.trim() ? image : DEFAULT_IMAGE;
+  const absoluteImage = resolvedImage.startsWith("http")
+    ? resolvedImage
+    : `${SITE_URL}${resolvedImage}`;
 
   return {
     title: fullTitle,

--- a/web-buddy/tests/og-image.spec.ts
+++ b/web-buddy/tests/og-image.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test("collectionbuddy og:image falls back to the default logo, not the homepage", async ({
+  request,
+  baseURL,
+}) => {
+  const response = await request.get(`${baseURL}/tools/collectionbuddy`);
+  const html = await response.text();
+
+  const match = html.match(/<meta property="og:image" content="([^"]+)"/);
+  expect(match).not.toBeNull();
+
+  const ogImage = match![1];
+  expect(ogImage).not.toBe("https://nobuddy.org/");
+  expect(ogImage).toBe("https://nobuddy.org/nobuddy_logo_preview.webp");
+});


### PR DESCRIPTION
## Summary
- `createMetadata`'s `image = "/nobuddy_logo_preview.webp"` default parameter only applies when the argument is `undefined`. Collection Buddy has `previewImage: ""` in `tools.ts`, so the empty string passed through and `og:image` resolved to exactly `https://nobuddy.org/` — an HTML page, not an image. Live-verified before the fix.
- `createMetadata` now falls back to the default logo whenever `image` is blank (`image.trim()` falsy), not just when it's `undefined`.
- Karma Buddy and Peek Buddy carry the same `""` sentinel for when they ship, so this also prevents the same bug from recurring for them.

Closes #396

## Test plan
- [x] `npm run build` then grepped `out/tools/collectionbuddy.html` — `og:image` now correctly resolves to `https://nobuddy.org/nobuddy_logo_preview.webp`
- [x] New `tests/og-image.spec.ts` asserts this against the raw (unhydrated) HTML via Playwright's `request` fixture
- [x] `npx serve out -l 3000` + `npx playwright test` — 33/33 passing
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)