### PR TITLE
fix: point previewImage at logo files that actually exist in public/

### DIFF
--- a/web-buddy/src/app/tools/tools.ts
+++ b/web-buddy/src/app/tools/tools.ts
@@ -71,7 +71,7 @@ export const tools = [
     description:
       "Effortlessly split costs with friends. A social-friendly app for fair finance, powered by DynamoDB and designed for group sharing.",
     logo: "/logos/fair.webp",
-    previewImage: "/logos/fair_preview.png",
+    previewImage: "/logos/fair.png",
     tags: [
       "Finance",
       "Social",
@@ -91,7 +91,7 @@ export const tools = [
     description:
       "Merge GPX tracks from multiple cycling sessions. Ideal for Strava users, activity aggregators, and route cleanup enthusiasts.",
     logo: "/logos/ridemerge.webp",
-    previewImage: "/logos/ridemerge_preview.png",
+    previewImage: "/logos/ridemerge.png",
     tags: ["Cycling", "GPX", "Strava", "Tracking", "Angular", "Tools"],
     github: `${GITHUB_URL}/RideMergeBuddy`,
     status: "ready",
@@ -102,7 +102,7 @@ export const tools = [
     description:
       "Find and visualize geocaching power trails with ease. Designed for efficiency-focused cachers who love long trails and rapid finds.",
     logo: "/logos/powertrail.webp",
-    previewImage: "/logos/powertrail_preview.png",
+    previewImage: "/logos/powertrail.png",
     tags: ["Geocaching", "Maps", "Navigation", "Trails", "Next.js", "Outdoor"],
     github: `${GITHUB_URL}/PowerTrailBuddy`,
     status: "coming_soon",

--- a/web-buddy/tests/asset-paths.spec.ts
+++ b/web-buddy/tests/asset-paths.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+import { existsSync } from "fs";
+import path from "path";
+import { tools } from "../src/app/tools/tools";
+
+const publicDir = path.join(__dirname, "..", "public");
+
+for (const tool of tools) {
+  test(`${tool.slug} logo and previewImage resolve to real files in public/`, () => {
+    expect(existsSync(path.join(publicDir, tool.logo))).toBe(true);
+
+    if (tool.previewImage) {
+      expect(existsSync(path.join(publicDir, tool.previewImage))).toBe(true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `tools.ts` pointed Ride Merge Buddy (status `ready`, live) at `/logos/ridemerge_preview.png`, but `public/logos/` only ever contained `ridemerge.png`/`.webp` — no `_preview.png` variant exists. `og:image` and JSON-LD `image` URLs 404'd in production, breaking social link previews. The same latent bug existed for Fair Buddy and Power Trail Buddy (currently `coming_soon`, so unobserved until they ship).
- Points all three at their existing `.png` logo file instead of the nonexistent `_preview.png`.
- Adds `tests/asset-paths.spec.ts` asserting every tool's `logo` and `previewImage` resolves to a real file under `public/`, so this class of bug fails CI going forward instead of only being caught by live-checking production.

Closes #397

## Test plan
- [x] `npm run build` then grepped `out/tools/ridemergebuddy.html` — `og:image` now resolves to `https://nobuddy.org/logos/ridemerge.png` (a file that exists)
- [x] `npx serve out -l 3000` + `npx playwright test` — 42/42 passing (9 new asset-existence checks, one per tool)
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)