### PR TITLE
fix: wire up the loaded Inter font and give font-mono a real stack

### DIFF
--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -8,8 +8,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
+    "Liberation Mono", monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,7 +23,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }
 
 html,

--- a/web-buddy/tests/fonts.spec.ts
+++ b/web-buddy/tests/fonts.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("font wiring", () => {
+  test("body uses the loaded Inter font, not the Arial fallback", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const bodyFont = await page.evaluate(
+      () => getComputedStyle(document.body).fontFamily
+    );
+
+    expect(bodyFont.toLowerCase()).toContain("inter");
+  });
+
+  test("terminal intro renders in a real monospace stack", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const terminalFont = await page.evaluate(() => {
+      const el = document.querySelector(".font-mono");
+      return el ? getComputedStyle(el).fontFamily : null;
+    });
+
+    expect(terminalFont).not.toBeNull();
+    expect(terminalFont).not.toContain("--font-geist-mono");
+    expect(terminalFont!.toLowerCase()).toMatch(/mono|consolas/);
+  });
+});


### PR DESCRIPTION
## Summary
- `--font-sans`/`--font-mono` pointed at `--font-geist-sans`/`--font-geist-mono`, which were never defined anywhere (leftover create-next-app wiring). Meanwhile `layout.tsx` loaded Google font Inter into `--font-inter`, which nothing consumed, and `body` hardcoded `font-family: Arial, Helvetica, sans-serif`.
- Consequence: the terminal intro's `font-mono` resolved to the inherited Arial fallback — the ASCII progress bar (`[█████░░░░░]`) visibly jittered in a proportional font — and ~48 KB of Inter woff2 preloaded high-priority on every page for a font that was never actually applied.
- Points `--font-sans` at `--font-inter` and `body`'s `font-family` at `--font-sans` (dropping the Arial override), and gives `--font-mono` a real system monospace stack.

Closes #398

## Test plan
- [x] `npm run build`
- [x] New `tests/fonts.spec.ts` asserts the body's computed `font-family` contains "Inter" and the terminal's `.font-mono` element resolves to a real monospace stack (not the literal unresolved `--font-geist-mono` var)
- [x] `npx serve out -l 3000` + `npx playwright test` — 44/44 passing (single-worker; a known pre-existing flake in the reduced-motion canvas-diff test under parallel load, unrelated to this change, is tracked separately by #404)
- [x] `prek run` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)