### PR TITLE
fix: run the e2e suite in the deploy workflow before publishing

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -32,7 +32,25 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: test -d out && test -f out/index.html
+
+      # A commit can reach main through a non-PR path (direct push, since
+      # admins are exempt from branch protection and force pushes are
+      # allowed), so re-run the e2e suite here rather than trusting that
+      # ci.yml's push-triggered run — which races this workflow — passed.
+      - run: npx playwright install --with-deps chromium
+      - run: npx serve@latest out -l 3000 &
+      - run: |
+          timeout 30s bash -c 'until curl -sSf http://localhost:3000 > /dev/null; do sleep 1; done'
+      - run: npx playwright test
+
       - run: touch out/.nojekyll
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: pages-deploy-playwright-report
+          path: web-buddy/playwright-report/
+          retention-days: 30
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:


### PR DESCRIPTION
## Summary
- `pages-deploy.yml` built and published to GitHub Pages on every push to `main` without ever running Playwright, and raced `ci.yml`'s own push-triggered run rather than depending on it. Any commit reaching `main` through a non-PR path (direct push — admins are exempt from branch protection and force pushes are allowed) or a semantic-merge break between two individually-green PRs went live with zero test execution.
- Adds the same build → serve → `playwright test` steps `ci.yml` uses to the deploy job's `build`, so a failing e2e blocks the `upload-pages-artifact` step and nothing broken reaches `actions/deploy-pages`.

I considered gating deploy on `workflow_run` (CI success) instead of duplicating the e2e run, which would avoid the duplication — but zizmor flags `workflow_run` as a fundamentally risky trigger (`dangerous-triggers`, high severity) and I didn't want to introduce that footgun. Went with the issue's other suggested option instead.

Closes #399

## Test plan
- [x] `prek run` (yaml validity + zizmor + shellcheck) on the changed workflow — all pass
- [x] The added steps mirror `ci.yml`'s already-proven `build_and_test` job (background `serve`, curl-poll wait, `playwright test`) verbatim, so the pattern is known-working on this runner image
- [x] `pages-deploy.yml` only triggers on push to `main`/`workflow_dispatch`, so it can't be exercised on a PR branch; since triggering `workflow_dispatch` would deploy that branch's build to production nobuddy.org, I didn't dispatch it manually to test — I'll watch the real deploy run once this merges to main and follow up immediately if it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)