### PR TITLE
test: derive e2e assertions from tools.ts instead of magic numbers

### DIFF
--- a/web-buddy/src/app/tools/page-toolgrid.tsx
+++ b/web-buddy/src/app/tools/page-toolgrid.tsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 import { tools } from "./tools";
 import { useState, useEffect } from "react";
 
-const ITEMS_PER_PAGE = 6;
+export const ITEMS_PER_PAGE = 6;
 
 const MotionLink = motion(Link);
 

--- a/web-buddy/tests/about.spec.ts
+++ b/web-buddy/tests/about.spec.ts
@@ -14,8 +14,9 @@ test("navigate to About page and verify content", async ({ page }) => {
   await expect(aboutHeading).toBeVisible();
   await expect(aboutHeading).toHaveText(/About/i);
 
+  const languageSections = page.locator("h2", { hasText: /English|Deutsch/ });
   const contactEmail = page.locator("p", { hasText: "info@nobuddy.org" });
-  await expect(contactEmail).toHaveCount(2);
+  await expect(contactEmail).toHaveCount(await languageSections.count());
   await expect(contactEmail.first()).toBeVisible();
 
   const disclaimerText = page.locator("text=This project is purely private");

--- a/web-buddy/tests/main.spec.ts
+++ b/web-buddy/tests/main.spec.ts
@@ -1,4 +1,14 @@
 import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+import { ITEMS_PER_PAGE } from "../src/app/tools/page-toolgrid";
+
+const pageOne = tools.slice(0, ITEMS_PER_PAGE);
+const pageTwo = tools.slice(ITEMS_PER_PAGE);
+const pageOneReady = pageOne.filter((t) => t.status === "ready");
+const pageOneComingSoon = pageOne.filter((t) => t.status !== "ready");
+const pageTwoReady = pageTwo.filter((t) => t.status === "ready");
+const pageTwoComingSoon = pageTwo.filter((t) => t.status !== "ready");
+const firstReadyTool = pageOneReady[0];
 
 test.describe("NoBuddy main page - cards section", () => {
   test.beforeEach(async ({ page }) => {
@@ -6,26 +16,31 @@ test.describe("NoBuddy main page - cards section", () => {
     await expect(
       page.getByRole("heading", { name: "The Buddy Compendium" })
     ).toBeVisible();
-    await expect(page.getByRole("link")).toHaveCount(11);
+    await expect(page.locator("#tools a")).toHaveCount(pageOneReady.length);
   });
 
-  test("has exactly 4 enabled card in #tools", async ({ page }) => {
+  test(`has exactly ${pageOneReady.length} enabled card(s) in #tools`, async ({
+    page,
+  }) => {
     const enabledCards = page.getByTestId("ready");
-    await expect(enabledCards).toHaveCount(5);
+    await expect(enabledCards).toHaveCount(pageOneReady.length);
     await expect(enabledCards.first()).toBeVisible();
   });
 
   test("first enabled card has correct href", async ({ page }) => {
-    const firstEnabledCardLink = page
-      .locator('#tools a[href^="/tools/"]')
-      .first();
+    const firstEnabledCardLink = page.getByRole("link", {
+      name: new RegExp(firstReadyTool.name),
+    });
     await expect(firstEnabledCardLink).toBeVisible();
-    await expect(firstEnabledCardLink).toHaveAttribute("href", /^\/tools\//);
+    await expect(firstEnabledCardLink).toHaveAttribute(
+      "href",
+      `/tools/${firstReadyTool.slug}`
+    );
   });
 
   test("disabled cards exist and are not clickable", async ({ page }) => {
     const disabledCards = page.getByTestId("coming_soon");
-    await expect(disabledCards).toHaveCount(1);
+    await expect(disabledCards).toHaveCount(pageOneComingSoon.length);
 
     const firstDisabledCard = disabledCards.first();
 
@@ -37,16 +52,16 @@ test.describe("NoBuddy main page - cards section", () => {
   test("clicking the first enabled card navigates and shows content", async ({
     page,
   }) => {
-    const firstEnabledCardLink = page
-      .locator('#tools a[href^="/tools/"]')
-      .first();
+    const firstEnabledCardLink = page.getByRole("link", {
+      name: new RegExp(firstReadyTool.name),
+    });
     await expect(firstEnabledCardLink).toBeVisible();
 
     await firstEnabledCardLink.click();
     await page.waitForLoadState("networkidle");
 
-    await expect(page).toHaveURL(/\/tools\/procrastinationbuddy/);
-    await expect(page.locator("h1")).toContainText(/Procrastination Buddy/i);
+    await expect(page).toHaveURL(new RegExp(`/tools/${firstReadyTool.slug}`));
+    await expect(page.locator("h1")).toContainText(firstReadyTool.name);
   });
 
   test("click on pagination 2 navigates to the second page", async ({
@@ -58,9 +73,9 @@ test.describe("NoBuddy main page - cards section", () => {
     await paginationLink.click();
 
     const disabledCards = page.getByTestId("coming_soon");
-    await expect(disabledCards).toHaveCount(3);
+    await expect(disabledCards).toHaveCount(pageTwoComingSoon.length);
 
     const enabledCards = page.getByTestId("ready");
-    await expect(enabledCards).toHaveCount(0);
+    await expect(enabledCards).toHaveCount(pageTwoReady.length);
   });
 });


### PR DESCRIPTION
## Summary
- Every count/ordering assertion in `main.spec.ts` restated `tools.ts` as a hardcoded literal: `toHaveCount(11)` for page-wide links in `beforeEach` (adding one footer link would fail all five tests at setup), `toHaveCount(5)` under a test literally named "has exactly 4 enabled card in #tools" (stale from a previous manual bump), a positional pin of the first card to `/tools/procrastinationbuddy`, and page-2 counts of 3/0.
- Exports `ITEMS_PER_PAGE` from `page-toolgrid.tsx` and imports it plus `tools` in `main.spec.ts` to derive all expectations (ready/coming_soon counts per page, the first ready tool's slug/name) from the actual data.
- Scopes the link-count assertion to `#tools` instead of the whole page, and selects the target card by accessible name instead of a hardcoded position, per the issue's suggested fix.
- Also derives `about.spec.ts`'s contact-email count from the About page's actual language sections (`h2` "English"/"Deutsch") instead of a bare `2` literal.

Closes #402

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx serve out -l 3000` + `npx playwright test` — 44/44 passing (single-worker)
- [x] `prek run` on changed files — all hooks pass, including ESLint

🤖 Generated with [Claude Code](https://claude.com/claude-code)