### PR TITLE
test: assert the structural invariant for disabled tool cards

### DIFF
--- a/web-buddy/tests/main.spec.ts
+++ b/web-buddy/tests/main.spec.ts
@@ -42,11 +42,11 @@ test.describe("NoBuddy main page - cards section", () => {
     const disabledCards = page.getByTestId("coming_soon");
     await expect(disabledCards).toHaveCount(pageOneComingSoon.length);
 
-    const firstDisabledCard = disabledCards.first();
-
-    const urlBefore = page.url();
-    await firstDisabledCard.click({ timeout: 1000 }).catch(() => {});
-    await expect(page).toHaveURL(urlBefore);
+    // Structural invariant: a coming-soon card must not be wrapped in an
+    // <a>, so it cannot navigate no matter how it's interacted with.
+    await expect(
+      disabledCards.first().locator("xpath=ancestor::a")
+    ).toHaveCount(0);
   });
 
   test("clicking the first enabled card navigates and shows content", async ({


### PR DESCRIPTION
## Summary
- The "disabled cards are not clickable" test recorded \`urlBefore\`, clicked with \`.catch(() => {})\` (swallowing every click error), then asserted \`toHaveURL(urlBefore)\` — a polling assertion whose expected value already holds at poll #1, before any client-side navigation would complete. It passed instantly even if navigation then happened, so the test could never fail for the regression it was named after.
- Replaces it with a structural assertion: a coming-soon card has no ancestor \`<a>\`, so it cannot navigate no matter how it's interacted with.

Closes #403

## Test plan
- [x] Red/green verified per the issue's suggested approach: temporarily changed \`page-toolgrid.tsx\`'s \`if (isReady)\` to \`if (true)\` (wrapping every card, including coming-soon ones, in a \`Link\`) and ran the test in isolation — it failed (\`Expected: 0, Received: 1\` ancestor \`<a>\`) — then reverted both files and confirmed the full suite is green again
- [x] \`npx serve out -l 3000\` + \`npx playwright test\` — 44/44 passing (single-worker)
- [x] \`prek run\` on the changed file — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)