### PR TITLE
fix: make Playwright flakiness visible instead of silently retried away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,16 +76,19 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
 
-      - name: Upload Playwright report if tests fail
-        if: failure()
+      - name: Upload Playwright report
+        # Uploaded even on a passing job: a test that fails then passes on
+        # retry still leaves flake evidence in the report/traces, and that
+        # evidence is lost if this only runs on failure().
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: web-buddy/playwright-report/
           retention-days: 30
 
-      - name: Upload Playwright traces if tests fail
-        if: failure()
+      - name: Upload Playwright traces
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-traces

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - run: touch out/.nojekyll
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: failure()
+        if: ${{ !cancelled() }}
         with:
           name: pages-deploy-playwright-report
           path: web-buddy/playwright-report/

--- a/web-buddy/playwright.config.ts
+++ b/web-buddy/playwright.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: process.env.CI ? [["list"], ["html"]] : "html",
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary
- \`retries: 2\` + the html-only reporter + \`if: failure()\`-gated artifact upload meant a test that failed then passed on retry left zero trace in CI: the html reporter emits almost nothing to the job log, and \`if: failure()\` skips uploading the report/traces once the retry passes the job. Flakiness accumulated unmeasured until a test failed three times in a row and blocked a random Dependabot PR, with no history to diagnose it.
- \`reporter: [["list"], ["html"]]\` in CI so retried failures are visible directly in the job log, not just inside a report artifact nobody downloads.
- \`retries: 1\` instead of 2 — a test that needs two retries to go green is flaky enough to warrant investigation, not papering over further.
- Upload the Playwright report/traces with \`if: !cancelled()\` in both \`ci.yml\` and \`pages-deploy.yml\` (the latter added in #399, same anti-pattern), so retry evidence survives a green job instead of only a red one.

Closes #404

## Test plan
- [x] Red/green verified per the issue's suggested approach: added a deliberately flaky sample test (fails once, passes on retry) and ran it with \`CI=true npx playwright test\` — the \`list\` reporter printed the failure, the retry, and \`1 flaky\` directly to the log, and \`playwright-report/\` was generated regardless of the job's overall pass — confirming this evidence now reaches CI. Removed the sample after confirming.
- [x] \`npx serve out -l 3000\` + \`npx playwright test\` — 44/44 passing (single-worker, real suite)
- [x] \`prek run\` on changed files — all hooks (incl. zizmor) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)