### PR TITLE
fix: make the terminal intro skippable and not replay within a session

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useState, useCallback } from "react";
 import type { CSSProperties } from "react";
 import { SITE_NAME, GITHUB_URL } from "../globals";
 import Link from "next/link";
+
+const SESSION_KEY = "terminalIntroPlayed";
 
 const fadeInStyle = {
   animationDuration: "0.3s",
@@ -64,6 +66,14 @@ const scriptLines: ScriptLine[] = [
   { role: "output", text: "↳ You’ve reached The Buddy Compendium." },
 ];
 
+function buildCompletedLines(): ScriptLine[] {
+  return scriptLines.map((line) =>
+    line.text.startsWith(loadingMessage)
+      ? { ...line, text: `${loadingMessage} ${loadingSteps[loadingSteps.length - 1]}` }
+      : line
+  );
+}
+
 type Phase = "lines" | "loading" | "wait";
 
 function Hero() {
@@ -101,12 +111,53 @@ export default function TerminalIntro() {
   const [phase, setPhase] = useState<Phase>("lines");
   const [lineIndex, setLineIndex] = useState(0);
   const [loadingIndex, setLoadingIndex] = useState(0);
+  const [skipAnimation, setSkipAnimation] = useState(false);
 
   const appendLine = useCallback((line: ScriptLine) => {
     setLines((prev) => [...prev, line]);
   }, []);
 
+  const finishNow = useCallback(() => {
+    setSkipAnimation(true);
+    setLines(buildCompletedLines());
+    setLineIndex(scriptLines.length);
+    setLoadingIndex(loadingSteps.length - 1);
+    setPhase("wait");
+  }, []);
+
+  // Render the completed terminal instantly on repeat visits within the
+  // same session instead of replaying the ~5s typing animation every time.
+  // useLayoutEffect (not useEffect) so this resolves before the browser
+  // paints the empty, server-rendered terminal.
+  useLayoutEffect(() => {
+    if (sessionStorage.getItem(SESSION_KEY)) {
+      finishNow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // A click or keypress anywhere fast-forwards straight to the finished
+  // state instead of forcing visitors to sit through the whole animation.
   useEffect(() => {
+    if (skipAnimation) return;
+    const handleSkip = () => finishNow();
+    window.addEventListener("click", handleSkip);
+    window.addEventListener("keydown", handleSkip);
+    return () => {
+      window.removeEventListener("click", handleSkip);
+      window.removeEventListener("keydown", handleSkip);
+    };
+  }, [skipAnimation, finishNow]);
+
+  useEffect(() => {
+    if (phase === "wait") {
+      sessionStorage.setItem(SESSION_KEY, "1");
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (skipAnimation) return;
+
     if (phase === "lines" && lineIndex < scriptLines.length) {
       const current = scriptLines[lineIndex];
 
@@ -153,7 +204,7 @@ export default function TerminalIntro() {
       const t = setTimeout(() => setPhase("wait"), 0);
       return () => clearTimeout(t);
     }
-  }, [phase, lineIndex, loadingIndex, appendLine]);
+  }, [phase, lineIndex, loadingIndex, appendLine, skipAnimation]);
 
   return (
     <div className="flex flex-col items-center px-4 pt-20 md:pt-32">

--- a/web-buddy/tests/terminal-skip.spec.ts
+++ b/web-buddy/tests/terminal-skip.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("terminal intro skip and session persistence", () => {
+  test("a click fast-forwards the terminal instead of forcing the full ~5s animation", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Click almost immediately, well before the animation would naturally
+    // finish (measured at ~5s in the issue).
+    await page.waitForTimeout(200);
+    await page.mouse.click(10, 10);
+
+    await expect(
+      page.getByText("Scroll down to continue...")
+    ).toBeVisible({ timeout: 1000 });
+  });
+
+  test("a keypress fast-forwards the terminal", async ({ page }) => {
+    await page.goto("/");
+
+    await page.waitForTimeout(200);
+    await page.keyboard.press("Space");
+
+    await expect(
+      page.getByText("Scroll down to continue...")
+    ).toBeVisible({ timeout: 1000 });
+  });
+
+  test("the terminal does not replay within the same session", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.mouse.click(10, 10);
+    await expect(
+      page.getByText("Scroll down to continue...")
+    ).toBeVisible({ timeout: 1000 });
+
+    await page.goto("/tools");
+    await page.goto("/");
+
+    // On the repeat visit the completed terminal renders immediately,
+    // without waiting for the typing animation to play out again.
+    await expect(
+      page.getByText("Scroll down to continue...")
+    ).toBeVisible({ timeout: 500 });
+  });
+});


### PR DESCRIPTION
## Summary
- \`TerminalIntro\`'s only logic was a timer chain (700/500ms per line, 80ms ticks) with no click/keypress handler and no \`sessionStorage\`/\`localStorage\` anywhere in \`src/\`. The "Scroll down to continue" cue rendered only after completion (~5s after navigation, per the issue's measurement), and nothing was persisted, so navigating Tools → logo → home replayed the entire typing animation from an empty terminal every time.
- A click or keypress anywhere now fast-forwards straight to the finished state (\`finishNow()\`), instead of forcing visitors to sit through the whole animation.
- The finished state (whether reached naturally or via skip) is recorded in a \`sessionStorage\` flag; a \`useLayoutEffect\` checks it on mount and renders the completed terminal instantly on repeat visits within the same session — \`useLayoutEffect\` specifically so this resolves before the browser paints the empty, server-rendered terminal, avoiding a flash.

Closes #410

## Test plan
- [x] Red/green verified per the issue's suggested approach: wrote \`tests/terminal-skip.spec.ts\` (click-to-skip, keypress-to-skip, no-replay-within-session), confirmed all 3 fail against the pre-fix component (skip cue never appears within 1s), restored the fix, confirmed all 3 pass
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 64/64 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)