### PR TITLE
fix: show the hero subtitle and GitHub CTA on mobile

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -86,7 +86,7 @@ function Hero() {
         {SITE_NAME}
       </h1>
 
-      <h2 className="hidden md:block relative z-10 max-w-3xl mx-auto text-lg sm:text-xl text-neutral-750 dark:text-neutral-150 mb-8">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-base sm:text-lg md:text-xl text-neutral-750 dark:text-neutral-150 mb-6 md:mb-8">
         Explore nobuddy.org – a playground of creative tools, weird ideas &
         useful mini-apps. Built for curious minds, developers, and digital
         explorers.
@@ -96,7 +96,7 @@ function Hero() {
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="hidden md:inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-8 py-3 rounded-full shadow-lg hover:bg-gray-900 transition"
+        className="inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-6 py-2.5 md:px-8 md:py-3 text-sm sm:text-base rounded-full shadow-lg hover:bg-gray-900 transition"
         aria-label="Follow Nobuddyorg on GitHub"
         title="follow on github"
       >

--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -18,6 +18,22 @@ test.describe("homepage hero and manifesto content", () => {
     ).toBeVisible({ timeout: 15000 });
   });
 
+  test("shows the value proposition and primary CTA on a mobile viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+
+    await expect(
+      page.getByText(
+        "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Follow Nobuddyorg on GitHub" })
+    ).toBeVisible();
+  });
+
   test("renders the manifesto sections", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
## Summary
- The hero subtitle — the only sentence on the site explaining what nobuddy.org is — and the "Follow on GitHub" button were both unconditionally hidden on phones (\`hidden md:block\` / \`hidden md:inline-block\`). Verified at 375×667: neither was visible, so phone visitors got a title plus an initially empty terminal box that types jokes for ~5 seconds, with no explanation of the site or action to take.
- Drops the \`hidden\` classes and tunes sizing down for small screens (\`text-base sm:text-lg md:text-xl\` for the subtitle, smaller button padding/text on mobile) so both fit comfortably above the terminal instead of overflowing or crowding the layout.

Closes #411

## Test plan
- [x] Red/green verified per the issue's suggested approach: added a mobile-viewport (375×667) test asserting subtitle + CTA visibility, confirmed it fails against the pre-fix component (\`hidden\` → \`unexpected value "hidden"\`), restored the fix, confirmed it passes
- [x] Screenshotted the mobile hero post-fix — subtitle and button both render cleanly above the terminal
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 65/65 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)