### PR TITLE
fix: add missing dark: hover variants (black-on-black in dark mode)

### DIFF
--- a/web-buddy/src/app/components/Footer.tsx
+++ b/web-buddy/src/app/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
           href={SITE_URL}
           target="_blank"
           rel="noopener"
-          className="underline hover:text-black transition"
+          className="underline hover:text-black dark:hover:text-white transition"
           title="home"
         >
           {AUTHOR_NAME}
@@ -19,7 +19,7 @@ export default function Footer() {
           href={GITHUB_URL}
           target="_blank"
           rel="noreferrer"
-          className="underline hover:text-black transition"
+          className="underline hover:text-black dark:hover:text-white transition"
           title="github"
         >
           GitHub

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -96,7 +96,7 @@ function Hero() {
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-6 py-2.5 md:px-8 md:py-3 text-sm sm:text-base rounded-full shadow-lg hover:bg-gray-900 transition"
+        className="inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-6 py-2.5 md:px-8 md:py-3 text-sm sm:text-base rounded-full shadow-lg hover:bg-gray-900 dark:hover:bg-gray-100 transition"
         aria-label="Follow Nobuddyorg on GitHub"
         title="follow on github"
       >

--- a/web-buddy/tests/dark-mode-hover.spec.ts
+++ b/web-buddy/tests/dark-mode-hover.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Tailwind v4's computed colors can come back as oklab()/oklch(), not just
+// rgb(). Normalize via a canvas, which every browser resolves to rgba()
+// reliably regardless of the input color space.
+async function contrastRatio(page: Page, colorA: string, colorB: string) {
+  return page.evaluate(
+    ([a, b]) => {
+      const toRgb = (color: string) => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext("2d")!;
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 1, 1);
+        const [r, g, bch] = ctx.getImageData(0, 0, 1, 1).data;
+        return [r, g, bch];
+      };
+
+      const relativeLuminance = ([r, g, bch]: number[]) => {
+        const [rs, gs, bs] = [r, g, bch].map((c) => {
+          const s = c / 255;
+          return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+      };
+
+      const la = relativeLuminance(toRgb(a));
+      const lb = relativeLuminance(toRgb(b));
+      const [lighter, darker] = la > lb ? [la, lb] : [lb, la];
+      return (lighter + 0.05) / (darker + 0.05);
+    },
+    [colorA, colorB]
+  );
+}
+
+// These elements use the `transition` utility, so getComputedStyle
+// immediately after hover() can catch an interpolated mid-transition color
+// rather than the final hover value.
+const TRANSITION_SETTLE_MS = 300;
+
+async function hoverColors(page: Page, locator: string) {
+  const el = page.locator(locator).first();
+  await el.hover();
+  await page.waitForTimeout(TRANSITION_SETTLE_MS);
+  return el.evaluate((node) => {
+    const style = getComputedStyle(node);
+    return { bg: style.backgroundColor, color: style.color };
+  });
+}
+
+test.describe("dark mode hover contrast", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+  });
+
+  test("hero CTA stays readable on hover in dark mode", async ({ page }) => {
+    await page.goto("/");
+    await page.mouse.click(10, 10); // skip terminal animation
+
+    const { bg, color } = await hoverColors(
+      page,
+      'a[aria-label="Follow Nobuddyorg on GitHub"]'
+    );
+    expect(await contrastRatio(page, bg, color)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test("footer links stay readable on hover in dark mode", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    for (const name of ["nobuddy", "GitHub"]) {
+      const link = page.locator("footer a", { hasText: name }).first();
+      await link.hover();
+      await page.waitForTimeout(TRANSITION_SETTLE_MS);
+      const color = await link.evaluate(
+        (node) => getComputedStyle(node).color
+      );
+      const footerBg = await page
+        .locator("footer")
+        .evaluate((node) => getComputedStyle(node).backgroundColor);
+
+      expect(
+        await contrastRatio(page, footerBg, color)
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The hero "Follow on GitHub" button used \`bg-black dark:bg-white text-white dark:text-black ... hover:bg-gray-900\` — in dark mode the hover class overrode \`dark:bg-white\` while \`dark:text-black\` still applied, so the white pill went near-black with black text on hover (~1.1:1 contrast).
- Both footer links used \`underline hover:text-black\` with no \`dark:hover:\` variant on a \`dark:bg-black/80\` footer, so the link text disappeared under the cursor (1:1 contrast — literally invisible).
- \`Header.tsx\` already had the correct pattern (\`hover:text-black dark:hover:text-white\`) that these two spots missed.
- Adds \`dark:hover:bg-gray-100\` to the CTA and \`dark:hover:text-white\` to both footer links.

Closes #412

## Test plan
- [x] Red/green verified per the issue's suggested approach: wrote \`tests/dark-mode-hover.spec.ts\` computing WCAG contrast ratio between hover text/background colors (normalized via canvas \`getImageData\`, since Tailwind v4 reports colors as \`oklab()\`), confirmed both tests fail against the pre-fix components (CTA 1.18:1, footer 1:1 — literally black-on-black), restored the fix, confirmed both pass (≥4.5:1)
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 67/67 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)