### PR TITLE
fix: remove homepage scroll-jacking, restore native document scroll

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -50,7 +50,7 @@ function ManifestoSection({
   return (
     <section
       ref={ref}
-      className={`snap-start min-h-screen flex flex-col justify-center items-center text-center px-6 py-10 ${bg}`}
+      className={`min-h-screen flex flex-col justify-center items-center text-center px-6 py-10 ${bg}`}
     >
       <div className={`text-6xl mb-6 ${revealClass}`} style={fadeStyle(inView, 0, 20)}>
         {emoji}
@@ -77,7 +77,7 @@ function CallToActionSection() {
   return (
     <section
       ref={ref}
-      className="snap-start h-screen flex flex-col justify-center items-center text-center p-10 bg-lime-100 dark:bg-lime-900"
+      className="h-screen flex flex-col justify-center items-center text-center p-10 bg-lime-100 dark:bg-lime-900"
     >
       <div
         className={`text-xl sm:text-2xl mb-6 ${inView ? "fade-in-up" : "opacity-0"}`}

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -32,8 +32,8 @@ export default function HomePage() {
     <>
       <PageWrapper metadata={metadata} jsonLd={jsonLd} />
       <Header />
-      <main className="h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth motion-reduce:scroll-auto text-black dark:text-white overflow-x-hidden">
-        <section className="snap-start min-h-screen">
+      <main className="text-black dark:text-white overflow-x-hidden">
+        <section className="min-h-screen">
           <CirclesBackground variant="page2" />
           <TerminalIntro />
         </section>

--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -34,6 +34,18 @@ test.describe("homepage hero and manifesto content", () => {
     ).toBeVisible();
   });
 
+  test("manifesto sections are reachable via keyboard scrolling", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const cta = page.getByRole("link", { name: "Launch /tools →" });
+    await expect(cta).not.toBeInViewport();
+
+    await page.keyboard.press("End");
+    await expect(cta).toBeInViewport({ timeout: 3000 });
+  });
+
   test("renders the manifesto sections", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
## Summary
- \`<main>\` wrapped everything in \`h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth\` — the document itself never overflowed, so all scrolling happened inside this nested container.
- \`snap-mandatory\` forbade resting anywhere but section boundaries: every wheel tick or flick flipped a full viewport, fighting the snap to re-read a ~90-word manifesto paragraph, and six snap stops separated a new visitor from the "Launch /tools" CTA.
- The container was not keyboard-focusable and its manifesto sections contained no focusable elements, so arrow/PageDown/End did nothing and the manifesto content was effectively unreachable without a mouse (WCAG 2.1.1 Keyboard).
- Drops the nested scroll container entirely, per the issue's primary suggested fix — the document now scrolls normally, inherently keyboard-accessible (arrow keys, Page Down, spacebar, Home/End all work natively) with no JS or \`tabIndex\` workarounds needed.
- Removes the now-inert \`snap-start\` classes from the sections it applied to.

Closes #413

## Test plan
- [x] Red/green verified per the issue's suggested approach: added a keyboard-scroll e2e test (press \`End\`, assert the bottom CTA link comes into viewport), confirmed it fails against the pre-fix layout (\`viewport ratio 0\` — End does nothing since the document doesn't scroll), restored the fix, confirmed it passes
- [x] Manually verified the scroll-jack itself is gone: a 400px wheel scroll now rests at exactly \`scrollY: 400\` instead of snapping to the nearest full-viewport section boundary
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 68/68 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)