### PR TITLE
fix: swap footer text colors to meet WCAG AA contrast

### DIFF
--- a/web-buddy/src/app/components/Footer.tsx
+++ b/web-buddy/src/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import { SITE_URL, AUTHOR_NAME, GITHUB_URL } from "../globals";
 
 export default function Footer() {
   return (
-    <footer className="fixed bottom-0 left-0 w-full z-50 bg-white/80 dark:bg-black/80 backdrop-blur-sm border-t border-gray-200 dark:border-gray-800 py-3 md:py-6 text-center text-sm text-gray-400 dark:text-gray-600 px-4 sm:px-6">
+    <footer className="fixed bottom-0 left-0 w-full z-50 bg-white/80 dark:bg-black/80 backdrop-blur-sm border-t border-gray-200 dark:border-gray-800 py-3 md:py-6 text-center text-sm text-gray-600 dark:text-gray-400 px-4 sm:px-6">
       <p>
         Crafted with ♥️ by{" "}
         <a

--- a/web-buddy/tests/dark-mode-hover.spec.ts
+++ b/web-buddy/tests/dark-mode-hover.spec.ts
@@ -1,38 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-
-// Tailwind v4's computed colors can come back as oklab()/oklch(), not just
-// rgb(). Normalize via a canvas, which every browser resolves to rgba()
-// reliably regardless of the input color space.
-async function contrastRatio(page: Page, colorA: string, colorB: string) {
-  return page.evaluate(
-    ([a, b]) => {
-      const toRgb = (color: string) => {
-        const canvas = document.createElement("canvas");
-        canvas.width = 1;
-        canvas.height = 1;
-        const ctx = canvas.getContext("2d")!;
-        ctx.fillStyle = color;
-        ctx.fillRect(0, 0, 1, 1);
-        const [r, g, bch] = ctx.getImageData(0, 0, 1, 1).data;
-        return [r, g, bch];
-      };
-
-      const relativeLuminance = ([r, g, bch]: number[]) => {
-        const [rs, gs, bs] = [r, g, bch].map((c) => {
-          const s = c / 255;
-          return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-        });
-        return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
-      };
-
-      const la = relativeLuminance(toRgb(a));
-      const lb = relativeLuminance(toRgb(b));
-      const [lighter, darker] = la > lb ? [la, lb] : [lb, la];
-      return (lighter + 0.05) / (darker + 0.05);
-    },
-    [colorA, colorB]
-  );
-}
+import { contrastRatio } from "./utils/contrast";
 
 // These elements use the `transition` utility, so getComputedStyle
 // immediately after hover() can catch an interpolated mid-transition color

--- a/web-buddy/tests/footer-contrast.spec.ts
+++ b/web-buddy/tests/footer-contrast.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { contrastRatio } from "./utils/contrast";
+
+test.describe("footer text contrast", () => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`meets WCAG AA (4.5:1) in ${colorScheme} mode`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme });
+      await page.goto("/");
+
+      const footer = page.locator("footer");
+      const { color, bg } = await footer.evaluate((node) => {
+        const style = getComputedStyle(node);
+        return { color: style.color, bg: style.backgroundColor };
+      });
+
+      expect(await contrastRatio(page, bg, color)).toBeGreaterThanOrEqual(
+        4.5
+      );
+    });
+  }
+});

--- a/web-buddy/tests/utils/contrast.ts
+++ b/web-buddy/tests/utils/contrast.ts
@@ -1,0 +1,39 @@
+import type { Page } from "@playwright/test";
+
+// Tailwind v4's computed colors can come back as oklab()/oklch(), not just
+// rgb(). Normalize via a canvas, which every browser resolves to concrete
+// sRGB bytes (via getImageData) reliably regardless of the input color space.
+export async function contrastRatio(
+  page: Page,
+  colorA: string,
+  colorB: string
+) {
+  return page.evaluate(
+    ([a, b]) => {
+      const toRgb = (color: string) => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext("2d")!;
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 1, 1);
+        const [r, g, bch] = ctx.getImageData(0, 0, 1, 1).data;
+        return [r, g, bch];
+      };
+
+      const relativeLuminance = ([r, g, bch]: number[]) => {
+        const [rs, gs, bs] = [r, g, bch].map((c) => {
+          const s = c / 255;
+          return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+      };
+
+      const la = relativeLuminance(toRgb(a));
+      const lb = relativeLuminance(toRgb(b));
+      const [lighter, darker] = la > lb ? [la, lb] : [lb, la];
+      return (lighter + 0.05) / (darker + 0.05);
+    },
+    [colorA, colorB]
+  );
+}


### PR DESCRIPTION
## Summary
- The footer's base text was \`text-gray-400 dark:text-gray-600\` on \`bg-white/80 dark:bg-black/80\`: gray-400 on white ≈2.5:1 and gray-600 on ≈#0a0a0a ≈2.6:1, both far below the 4.5:1 WCAG 1.4.3 AA requires for 14px text. The footer is fixed and appears on every page, so low-vision users couldn't read the site attribution or find the GitHub/home links anywhere on the site.
- Swaps to \`text-gray-600 dark:text-gray-400\`, which meets 4.5:1 on these backgrounds.
- Extracts the \`contrastRatio\` test helper (canvas-normalized, handles Tailwind v4's \`oklab()\` computed colors — built for #412) from \`dark-mode-hover.spec.ts\` into \`tests/utils/contrast.ts\` so it's shared instead of duplicated, and reused here.

Closes #414

## Test plan
- [x] Red/green verified per the issue's suggested approach: added \`tests/footer-contrast.spec.ts\` checking the footer's default (non-hover) text contrast in both color schemes, confirmed it fails against the original colors (2.60:1 light, 2.78:1 dark — closely matching the issue's own measurements), restored the fix, confirmed it passes (≥4.5:1)
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 70/70 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)