### PR TITLE
fix: mark the German Impressum section lang="de"

### DIFF
--- a/web-buddy/src/app/about/page.tsx
+++ b/web-buddy/src/app/about/page.tsx
@@ -75,7 +75,10 @@ function EnglishSection() {
 
 function GermanSection() {
   return (
-    <div className="rounded-2xl p-6 border bg-white dark:bg-black border-gray-400 dark:border-gray-600 text-gray-700 dark:text-gray-300 space-y-4">
+    <div
+      lang="de"
+      className="rounded-2xl p-6 border bg-white dark:bg-black border-gray-400 dark:border-gray-600 text-gray-700 dark:text-gray-300 space-y-4"
+    >
       <h2 className="text-lg font-semibold mb-2">Deutsch</h2>
       <p>
         <strong>Verantwortlich für den Inhalt:</strong>

--- a/web-buddy/tests/about.spec.ts
+++ b/web-buddy/tests/about.spec.ts
@@ -22,3 +22,16 @@ test("navigate to About page and verify content", async ({ page }) => {
   const disclaimerText = page.locator("text=This project is purely private");
   await expect(disclaimerText).toBeVisible();
 });
+
+test("German Impressum section is marked lang=\"de\"", async ({ page }) => {
+  await page.goto("/about");
+
+  const germanHeading = page.getByRole("heading", { name: "Deutsch" });
+  const germanSection = page.locator('[lang="de"]', {
+    has: germanHeading,
+  });
+  await expect(germanSection).toHaveCount(1);
+  await expect(
+    germanSection.getByText("Haftungsausschluss")
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- \`GermanSection\` (the legally required Impressum: "Verantwortlich für den Inhalt… Haftungsausschluss…") had no \`lang\` attribute anywhere; the only \`lang\` in the codebase was \`html lang="en"\`. WCAG 3.1.2 Language of Parts (AA) requires passages in another language to be programmatically identified, and without it screen readers pronounce the German legal text with an English speech engine, rendering it largely unintelligible.
- Adds \`lang="de"\` to the \`GermanSection\` wrapper \`div\`.

Closes #415

## Test plan
- [x] Red/green verified per the issue's suggested approach: added an e2e test asserting the German block carries \`lang="de"\`, confirmed it fails against the pre-fix markup (0 matching elements), restored the fix, confirmed it passes
- [x] \`npm run lint\`, \`npm run build\`
- [x] \`npx playwright test\` — 71/71 passing (single-worker)
- [x] \`prek run\` on changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)