### PR TITLE
fix: correct package.json homepage and add license field

### DIFF
--- a/web-buddy/package.json
+++ b/web-buddy/package.json
@@ -2,7 +2,8 @@
   "name": "web-buddy",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://nobuddyorg.github.io",
+  "license": "MIT",
+  "homepage": "https://nobuddy.org",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- `homepage` pointed at the pre-custom-domain `nobuddyorg.github.io` URL; now matches `SITE_URL` (`https://nobuddy.org`) and `public/CNAME`.
- Added missing `"license": "MIT"` field matching the root LICENSE.

Fixes #448

## Test plan
- Verified `package.json` parses and fields read as expected.