### PR TITLE
fix: dedupe marketing copy into shared description constants

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useLayoutEffect, useState, useCallback } from "react";
 import type { CSSProperties } from "react";
-import { SITE_NAME, GITHUB_URL } from "../globals";
+import { SITE_NAME, GITHUB_URL, SITE_DESCRIPTION } from "../globals";
 import Link from "next/link";
 
 const SESSION_KEY = "terminalIntroPlayed";
@@ -87,9 +87,7 @@ function Hero() {
       </h1>
 
       <h2 className="block relative z-10 max-w-3xl mx-auto text-base sm:text-lg md:text-xl text-neutral-750 dark:text-neutral-150 mb-6 md:mb-8">
-        Explore nobuddy.org – a playground of creative tools, weird ideas &
-        useful mini-apps. Built for curious minds, developers, and digital
-        explorers.
+        {SITE_DESCRIPTION}
       </h2>
 
       <Link

--- a/web-buddy/src/app/globals.tsx
+++ b/web-buddy/src/app/globals.tsx
@@ -3,3 +3,7 @@ export const GITHUB_URL = "https://github.com/nobuddyorg";
 export const SITE_NAME = "Creative Tools for Nerds";
 export const AUTHOR_NAME = "nobuddy";
 export const LEGAL_AUTHOR = "Matthias Eggert";
+export const SITE_DESCRIPTION =
+  "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps. Built for curious minds, developers, and digital explorers.";
+export const TOOLS_DESCRIPTION =
+  "A growing collection of useful web tools with unique personality and practical features for creative problem-solving, including procrastination, load testing and other things.";

--- a/web-buddy/src/app/manifest.ts
+++ b/web-buddy/src/app/manifest.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { SITE_NAME, AUTHOR_NAME } from "./globals";
+import { SITE_NAME, AUTHOR_NAME, TOOLS_DESCRIPTION } from "./globals";
 
 export const dynamic = "force-static";
 
@@ -7,8 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: SITE_NAME,
     short_name: AUTHOR_NAME,
-    description:
-      "A growing collection of useful web tools with unique personality and practical features for creative problem-solving, including ProcrastinationBuddy, ThrashBuddy, and FairBuddy.",
+    description: TOOLS_DESCRIPTION,
     start_url: "/",
     display: "standalone",
     background_color: "#ffffff",

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -3,7 +3,7 @@ import ManifestoScroll from "./components/ManifestoScroll";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import PageWrapper from "./components/PageWrapper";
-import { SITE_URL, SITE_NAME } from "./globals";
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "./globals";
 import { createMetadata } from "./metadata";
 import CirclesBackground from "./components/CirclesBackground";
 
@@ -11,7 +11,7 @@ const title = SITE_NAME;
 const slug = "/";
 const url = `${SITE_URL}${slug}`;
 
-const description = "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps. Built for curious minds, developers, and digital explorers."
+const description = SITE_DESCRIPTION;
 
 export const metadata = createMetadata({
   title,

--- a/web-buddy/src/app/tools/page.tsx
+++ b/web-buddy/src/app/tools/page.tsx
@@ -1,4 +1,4 @@
-import { SITE_URL, SITE_NAME } from "../globals";
+import { SITE_URL, SITE_NAME, TOOLS_DESCRIPTION } from "../globals";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import ToolGrid from "./page-toolgrid";
@@ -10,7 +10,7 @@ const title = SITE_NAME;
 const slug = "/tools";
 const url = `${SITE_URL}${slug}`;
 
-const description = `A growing collection of useful web tools with unique personality and practical features for creative problem-solving, including procrastination, load testing and other things.`
+const description = TOOLS_DESCRIPTION;
 
 export const metadata = createMetadata({
   title,

--- a/web-buddy/tests/content-consistency.spec.ts
+++ b/web-buddy/tests/content-consistency.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import { SITE_DESCRIPTION, TOOLS_DESCRIPTION } from "../src/app/globals";
+
+test.describe("marketing copy stays in sync across surfaces", () => {
+  test("homepage meta description matches the hero subtitle", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const metaDescription = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content");
+    expect(metaDescription).toBe(SITE_DESCRIPTION);
+
+    await expect(page.locator("h2").first()).toHaveText(SITE_DESCRIPTION);
+  });
+
+  test("tools meta description matches the manifest description", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/tools");
+
+    const metaDescription = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content");
+    expect(metaDescription).toBe(TOOLS_DESCRIPTION);
+
+    const manifestResponse = await request.get("/manifest.webmanifest");
+    const manifestJson = await manifestResponse.json();
+    expect(manifestJson.description).toBe(TOOLS_DESCRIPTION);
+  });
+});


### PR DESCRIPTION
## Summary
- Homepage meta description and hero `<h2>` were character-identical but hand-duplicated; both now read `SITE_DESCRIPTION` from `globals.tsx`.
- `/tools` meta description and `manifest.ts` description had already drifted (manifest still named the unreleased FairBuddy); both now read `TOOLS_DESCRIPTION`.
- Added a regression test (`tests/content-consistency.spec.ts`) asserting the meta description matches the visible hero text, and the tools meta description matches the manifest description.

Fixes #446

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (full suite, 73 passed)