### PR TITLE
fix: add accessible names and aria-current to tools pagination

### DIFF
--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -159,11 +159,15 @@ function Pagination({
   onPageChange: (page: number) => void;
 }) {
   return (
-    <div className="w-fit mx-auto mt-0 rounded-2xl p-4 border bg-white/60 dark:bg-black/60 border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-[0_2px_8px_rgba(255,255,255,0.05)] backdrop-blur-sm mb-0 md:mb-10">
+    <nav
+      aria-label="Tools pagination"
+      className="w-fit mx-auto mt-0 rounded-2xl p-4 border bg-white/60 dark:bg-black/60 border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-[0_2px_8px_rgba(255,255,255,0.05)] backdrop-blur-sm mb-0 md:mb-10"
+    >
       <div className="flex justify-center gap-2 items-center text-sm">
         <button
           onClick={() => onPageChange(Math.max(1, currentPage - 1))}
           disabled={currentPage === 1}
+          aria-label="Previous page"
           className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40"
         >
           ◀
@@ -172,6 +176,8 @@ function Pagination({
           <button
             key={page}
             onClick={() => onPageChange(page)}
+            aria-label={`Page ${page}`}
+            aria-current={page === currentPage ? "page" : undefined}
             className={`px-3 py-1 rounded-full transition ${
               page === currentPage
                 ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-black ring-2 ring-black dark:ring-white"
@@ -184,11 +190,12 @@ function Pagination({
         <button
           onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
           disabled={currentPage === totalPages}
+          aria-label="Next page"
           className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40"
         >
           ▶
         </button>
       </div>
-    </div>
+    </nav>
   );
 }

--- a/web-buddy/tests/pagination-a11y.spec.ts
+++ b/web-buddy/tests/pagination-a11y.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("tools pagination accessibility", () => {
+  test("exposes a pagination landmark with accessible controls", async ({
+    page,
+  }) => {
+    await page.goto("/tools");
+
+    const nav = page.getByRole("navigation", { name: "Tools pagination" });
+    await expect(nav).toBeVisible();
+
+    await expect(nav.getByRole("button", { name: "Previous page" })).toBeVisible();
+    await expect(nav.getByRole("button", { name: "Next page" })).toBeVisible();
+    await expect(nav.getByRole("button", { name: "Page 1" })).toBeVisible();
+    await expect(nav.getByRole("button", { name: "Page 2" })).toBeVisible();
+  });
+
+  test("marks the active page with aria-current", async ({ page }) => {
+    await page.goto("/tools");
+
+    const nav = page.getByRole("navigation", { name: "Tools pagination" });
+    const pageOne = nav.getByRole("button", { name: "Page 1" });
+    const pageTwo = nav.getByRole("button", { name: "Page 2" });
+
+    await expect(pageOne).toHaveAttribute("aria-current", "page");
+    await expect(pageTwo).not.toHaveAttribute("aria-current", "page");
+
+    await pageTwo.click();
+
+    await expect(pageTwo).toHaveAttribute("aria-current", "page");
+    await expect(pageOne).not.toHaveAttribute("aria-current", "page");
+  });
+});


### PR DESCRIPTION
## Summary
- Prev/next pagination buttons had no accessible name beyond the glyph (`◀`/`▶`)
- Numbered page buttons announced as bare numbers with no context
- The selected page was conveyed only via CSS classes, not programmatically
- The button group wasn't a landmark

## Changes
- Added `aria-label="Previous page"` / `"Next page"` to the arrow buttons
- Added `aria-label={"Page " + page}` to numbered buttons
- Added `aria-current="page"` on the active page button
- Wrapped the group in `<nav aria-label="Tools pagination">`
- Added `tests/pagination-a11y.spec.ts` covering accessible names and `aria-current` toggling

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (75/75 passing)

Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)