### PR TITLE
fix: add /tools hub page to sitemap.xml

### DIFF
--- a/web-buddy/src/app/sitemap.ts
+++ b/web-buddy/src/app/sitemap.ts
@@ -24,6 +24,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${SITE_URL}/tools`,
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/about`,
       lastModified,
       changeFrequency: "monthly" as const,

--- a/web-buddy/tests/sitemap.spec.ts
+++ b/web-buddy/tests/sitemap.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+import { SITE_URL } from "../src/app/constants";
+
+test.describe("sitemap.xml", () => {
+  test("lists every real route: home, /tools hub, /about, and ready tool pages", async ({
+    request,
+  }) => {
+    const response = await request.get("/sitemap.xml");
+    const body = await response.text();
+
+    const expectedRoutes = [
+      SITE_URL,
+      `${SITE_URL}/tools`,
+      `${SITE_URL}/about`,
+      ...tools
+        .filter((tool) => tool.status === "ready")
+        .map((tool) => `${SITE_URL}/tools/${tool.slug}`),
+    ];
+
+    for (const route of expectedRoutes) {
+      expect(body).toContain(`<loc>${route}</loc>`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `sitemap.ts` listed the homepage, /about, and ready tool pages, but not `/tools` — the main hub linked in the global header with its own canonical URL and description
- No noindex or robots rule excludes it intentionally; the omission was unintentional

## Changes
- Added a `${SITE_URL}/tools` entry with priority 0.8 (between home's 1 and tool pages' 0.7)
- Added `tests/sitemap.spec.ts` asserting the sitemap contains all real routes (home, /tools, /about, ready tool pages)

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (74/74 passing)

Fixes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)