### PR TITLE
docs: add development, build, test, and deploy docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,42 @@
 
 ![nobuddy logo large](web-buddy/public/nobuddy_logo.webp)
 
-This repository contains the static pages of nobuddyorg.
+This repository contains the static pages of nobuddyorg, served at
+[nobuddy.org](https://nobuddy.org). The site is a Next.js app in
+[`web-buddy/`](web-buddy/), statically exported and deployed to GitHub Pages.
+
+## Development
+
+Prerequisites: Node 22 (see `web-buddy/.nvmrc`).
+
+```bash
+cd web-buddy
+npm ci
+npm run dev       # starts the dev server at http://localhost:3000
+```
+
+Other useful commands (run from `web-buddy/`):
+
+```bash
+npm run lint       # ESLint
+npm run build      # static export to web-buddy/out
+npm run test:e2e   # Playwright e2e tests (requires a prior build; see below)
+```
+
+The Playwright suite runs against the static export, so build first:
+
+```bash
+npm run build
+npx playwright test
+```
+
+From the repo root, `./build.sh` does a full local sanity check: a clean
+`npm ci` + `npm run build` of `web-buddy/`, producing `web-buddy/out/`.
+
+## Deployment
+
+Pushes to `main` automatically build and deploy the site to
+[nobuddy.org](https://nobuddy.org) via `.github/workflows/pages-deploy.yml`.
 
 ## Tools & Libraries Overview
 


### PR DESCRIPTION
## Summary
- The README was 11 lines: a logo and one sentence. It never mentioned the Next.js app in `web-buddy/`, `npm run dev`, `build.sh`, the Playwright e2e suite, or that pushes to `main` auto-deploy to nobuddy.org
- No `web-buddy/README.md` exists either; org sibling projects all ship full READMEs

## Changes
- Added a Development section: prerequisites (Node 22), `npm ci && npm run dev`, lint/build/test commands, and `./build.sh` for a local sanity check
- Added a Deployment section noting pushes to `main` auto-deploy via `pages-deploy.yml`

## Test plan
- [x] Followed the documented commands on a clean checkout (`npm run lint`, `npm run build`, `npx playwright test`) — all pass
- [x] `pre-commit run markdownlint-cli2 trailing-whitespace end-of-file-fixer editorconfig-checker typos --files README.md` — all pass

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)