### PR TITLE
fix: type and validate the tools.ts data array

### DIFF
--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -98,7 +98,7 @@ export default function ToolGrid() {
                 </p>
 
                 <div className="flex flex-wrap gap-2">
-                  {(tool.tags || []).map((tag) => (
+                  {tool.tags.map((tag) => (
                     <span
                       key={tag}
                       className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2 py-1 rounded-full font-medium"

--- a/web-buddy/src/app/tools/tools.ts
+++ b/web-buddy/src/app/tools/tools.ts
@@ -1,6 +1,18 @@
 import { GITHUB_URL } from "../constants";
 
-export const tools = [
+export interface Tool {
+  slug: string;
+  name: string;
+  tagline?: string;
+  description: string;
+  logo: string;
+  previewImage?: string;
+  tags: string[];
+  github: string;
+  status: "ready" | "coming_soon";
+}
+
+export const tools: Tool[] = [
   {
     slug: "procrastinationbuddy",
     name: "Procrastination Buddy",

--- a/web-buddy/tests/asset-paths.spec.ts
+++ b/web-buddy/tests/asset-paths.spec.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { tools } from "../src/app/tools/tools";
 
 const publicDir = path.join(__dirname, "..", "public");
+const toolsSrcDir = path.join(__dirname, "..", "src", "app", "tools");
 
 for (const tool of tools) {
   test(`${tool.slug} logo and previewImage resolve to real files in public/`, () => {
@@ -12,5 +13,15 @@ for (const tool of tools) {
     if (tool.previewImage) {
       expect(existsSync(path.join(publicDir, tool.previewImage))).toBe(true);
     }
+  });
+}
+
+const readyTools = tools.filter((tool) => tool.status === "ready");
+
+for (const tool of readyTools) {
+  test(`${tool.slug} has a matching route directory (status: ready)`, () => {
+    expect(existsSync(path.join(toolsSrcDir, tool.slug, "page.tsx"))).toBe(
+      true
+    );
   });
 }


### PR DESCRIPTION
## Summary
- `export const tools = [...]` had no declared element type: `status` inferred as `string` (not `"ready" | "coming_soon"`), no field was required, and nothing guaranteed `tags` existed — `ToolGrid.tsx` defensively wrote `(tool.tags || [])`

## Changes
- Added a `Tool` interface (`status: "ready" | "coming_soon"`, `tags: string[]` required, `tagline`/`previewImage` optional) and typed the array as `Tool[]`
- Removed the now-unneeded `(tool.tags || [])` fallback in `ToolGrid.tsx`
- Extended `tests/asset-paths.spec.ts` (which already checked logo/previewImage files resolve) with a check that every `status: "ready"` tool's slug has a matching `src/app/tools/<slug>/page.tsx` route

Note: the three broken preview-image paths and the `karmabudddy` slug typo mentioned in the issue are tracked separately (#430) and are out of scope here — current data already passes the new stricter types/validation without changes.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (78/78 passing)

Fixes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)