### PR TITLE
fix: wire tools.ts github field into tool pages, drop hardcoded hrefs

### DIFF
--- a/web-buddy/src/app/tools/collectionbuddy/client.tsx
+++ b/web-buddy/src/app/tools/collectionbuddy/client.tsx
@@ -50,7 +50,7 @@ const techStack: TechStackItem[] = [
   { name: "Open Street Map", url: "https://www.openstreetmap.org/" },
 ];
 
-function DescriptionSection() {
+function DescriptionSection({ githubUrl }: { githubUrl: string }) {
   return (
     <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
       <p>
@@ -63,7 +63,7 @@ function DescriptionSection() {
       <p>
         🔗{" "}
         <a
-          href="https://github.com/nobuddyorg/CollectionBuddy"
+          href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="underline hover:text-black dark:hover:text-white"
@@ -78,10 +78,12 @@ function DescriptionSection() {
 
 interface CollectionBuddyClientProps {
   title: string;
+  githubUrl: string;
 }
 
 export default function CollectionBuddyClient({
   title,
+  githubUrl,
 }: CollectionBuddyClientProps) {
   return (
     <ToolPageShell title={title}>
@@ -90,7 +92,7 @@ export default function CollectionBuddyClient({
         poster={`${imageDir}/preview-poster.jpg`}
         label="Collection Buddy animated preview"
       />
-      <DescriptionSection />
+      <DescriptionSection githubUrl={githubUrl} />
       <ToolScreenshots
         screenshots={screenshots}
         imageDir={imageDir}

--- a/web-buddy/src/app/tools/collectionbuddy/page.tsx
+++ b/web-buddy/src/app/tools/collectionbuddy/page.tsx
@@ -4,7 +4,8 @@ import JsonLd from "../../components/JsonLd";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const { title, metadata, jsonLd, jsonLdId } = getToolPageData("collectionbuddy");
+const { title, github, metadata, jsonLd, jsonLdId } =
+  getToolPageData("collectionbuddy");
 
 export { metadata };
 
@@ -13,7 +14,7 @@ export default function CollectionBuddyPage() {
     <>
       <JsonLd id={jsonLdId} data={jsonLd} />
       <Header />
-      <CollectionBuddyClient title={title} />
+      <CollectionBuddyClient title={title} githubUrl={github} />
       <Footer />
     </>
   );

--- a/web-buddy/src/app/tools/gamegallerybuddy/client.tsx
+++ b/web-buddy/src/app/tools/gamegallerybuddy/client.tsx
@@ -16,7 +16,13 @@ const techStack: TechStackItem[] = [
   { name: "Gradle", url: "https://gradle.org/" },
 ];
 
-export default function GameGalleryBuddyClient({ title }: { title: string }) {
+export default function GameGalleryBuddyClient({
+  title,
+  githubUrl,
+}: {
+  title: string;
+  githubUrl: string;
+}) {
   return (
     <ToolPageShell title={title}>
       <div
@@ -55,7 +61,7 @@ export default function GameGalleryBuddyClient({ title }: { title: string }) {
         <p>
           🔗{" "}
           <a
-            href="https://github.com/nobuddyorg/GameGalleryBuddy"
+            href={githubUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-black dark:hover:text-white"

--- a/web-buddy/src/app/tools/gamegallerybuddy/page.tsx
+++ b/web-buddy/src/app/tools/gamegallerybuddy/page.tsx
@@ -4,7 +4,8 @@ import JsonLd from "../../components/JsonLd";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const { title, metadata, jsonLd, jsonLdId } = getToolPageData("gamegallerybuddy");
+const { title, github, metadata, jsonLd, jsonLdId } =
+  getToolPageData("gamegallerybuddy");
 
 export { metadata };
 
@@ -13,7 +14,7 @@ export default function GameGalleryBuddyPage() {
     <>
       <JsonLd id={jsonLdId} data={jsonLd} />
       <Header />
-      <GameGalleryBuddyClient title={title} />
+      <GameGalleryBuddyClient title={title} githubUrl={github} />
       <Footer />
     </>
   );

--- a/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
+++ b/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
@@ -46,7 +46,7 @@ const techStack: TechStackItem[] = [
   { name: "uv", url: "https://github.com/astral-sh/uv" },
 ];
 
-function DescriptionSection() {
+function DescriptionSection({ githubUrl }: { githubUrl: string }) {
   return (
     <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
       <p>
@@ -62,7 +62,7 @@ function DescriptionSection() {
       <p>
         🔗{" "}
         <a
-          href="https://github.com/nobuddyorg/ProcrastinationBuddy"
+          href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="underline hover:text-black dark:hover:text-white"
@@ -77,10 +77,12 @@ function DescriptionSection() {
 
 interface ProcrastinationBuddyClientProps {
   title: string;
+  githubUrl: string;
 }
 
 export default function ProcrastinationBuddyClient({
   title,
+  githubUrl,
 }: ProcrastinationBuddyClientProps) {
   return (
     <ToolPageShell title={title}>
@@ -89,7 +91,7 @@ export default function ProcrastinationBuddyClient({
         poster={`${imageDir}/buddy-preview-poster.jpg`}
         label="Procrastination Buddy animated preview"
       />
-      <DescriptionSection />
+      <DescriptionSection githubUrl={githubUrl} />
       <ToolScreenshots
         screenshots={screenshots}
         imageDir={imageDir}

--- a/web-buddy/src/app/tools/procrastinationbuddy/page.tsx
+++ b/web-buddy/src/app/tools/procrastinationbuddy/page.tsx
@@ -4,7 +4,8 @@ import JsonLd from "../../components/JsonLd";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const { title, metadata, jsonLd, jsonLdId } = getToolPageData("procrastinationbuddy");
+const { title, github, metadata, jsonLd, jsonLdId } =
+  getToolPageData("procrastinationbuddy");
 
 export { metadata };
 
@@ -13,7 +14,7 @@ export default function ProcrastinationBuddyPage() {
     <>
       <JsonLd id={jsonLdId} data={jsonLd} />
       <Header />
-      <ProcrastinationBuddyClient title={title} />
+      <ProcrastinationBuddyClient title={title} githubUrl={github} />
       <Footer />
     </>
   );

--- a/web-buddy/src/app/tools/ridemergebuddy/client.tsx
+++ b/web-buddy/src/app/tools/ridemergebuddy/client.tsx
@@ -33,7 +33,7 @@ const techStack: TechStackItem[] = [
   { name: "Gradle", url: "https://gradle.org/" },
 ];
 
-function DescriptionSection() {
+function DescriptionSection({ githubUrl }: { githubUrl: string }) {
   return (
     <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
       <p>
@@ -43,7 +43,7 @@ function DescriptionSection() {
       <p>
         🔗{" "}
         <a
-          href="https://github.com/nobuddyorg/RideMergeBuddy"
+          href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="underline hover:text-black dark:hover:text-white"
@@ -58,14 +58,16 @@ function DescriptionSection() {
 
 interface RideMergeBuddyClientProps {
   title: string;
+  githubUrl: string;
 }
 
 export default function RideMergeBuddyClient({
   title,
+  githubUrl,
 }: RideMergeBuddyClientProps) {
   return (
     <ToolPageShell title={title}>
-      <DescriptionSection />
+      <DescriptionSection githubUrl={githubUrl} />
       <ToolScreenshots
         screenshots={screenshots}
         imageDir={imageDir}

--- a/web-buddy/src/app/tools/ridemergebuddy/page.tsx
+++ b/web-buddy/src/app/tools/ridemergebuddy/page.tsx
@@ -4,7 +4,8 @@ import JsonLd from "../../components/JsonLd";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const { title, metadata, jsonLd, jsonLdId } = getToolPageData("ridemergebuddy");
+const { title, github, metadata, jsonLd, jsonLdId } =
+  getToolPageData("ridemergebuddy");
 
 export { metadata };
 
@@ -13,7 +14,7 @@ export default function RideMergeBuddyPage() {
     <>
       <JsonLd id={jsonLdId} data={jsonLd} />
       <Header />
-      <RideMergeBuddyClient title={title} />
+      <RideMergeBuddyClient title={title} githubUrl={github} />
       <Footer />
     </>
   );

--- a/web-buddy/src/app/tools/thrashbuddy/client.tsx
+++ b/web-buddy/src/app/tools/thrashbuddy/client.tsx
@@ -46,7 +46,7 @@ const techStack: TechStackItem[] = [
   { name: "Minikube", url: "https://minikube.sigs.k8s.io/" },
 ];
 
-function DescriptionSection() {
+function DescriptionSection({ githubUrl }: { githubUrl: string }) {
   return (
     <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
       <p>
@@ -59,7 +59,7 @@ function DescriptionSection() {
       <p>
         🔗{" "}
         <a
-          href="https://github.com/nobuddyorg/ThrashBuddy"
+          href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="underline hover:text-black dark:hover:text-white"
@@ -74,10 +74,12 @@ function DescriptionSection() {
 
 interface ThrashBuddyClientProps {
   title: string;
+  githubUrl: string;
 }
 
 export default function ThrashBuddyClient({
   title,
+  githubUrl,
 }: ThrashBuddyClientProps) {
   return (
     <ToolPageShell title={title}>
@@ -86,7 +88,7 @@ export default function ThrashBuddyClient({
         poster="/images/thrash-buddy/preview-poster.jpg"
         label="Thrash Buddy animated preview"
       />
-      <DescriptionSection />
+      <DescriptionSection githubUrl={githubUrl} />
       <ToolScreenshots
         screenshots={screenshots}
         imageDir={imageDir}

--- a/web-buddy/src/app/tools/thrashbuddy/page.tsx
+++ b/web-buddy/src/app/tools/thrashbuddy/page.tsx
@@ -4,7 +4,8 @@ import JsonLd from "../../components/JsonLd";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
-const { title, metadata, jsonLd, jsonLdId } = getToolPageData("thrashbuddy");
+const { title, github, metadata, jsonLd, jsonLdId } =
+  getToolPageData("thrashbuddy");
 
 export { metadata };
 
@@ -13,7 +14,7 @@ export default function ThrashBuddyPage() {
     <>
       <JsonLd id={jsonLdId} data={jsonLd} />
       <Header />
-      <ThrashBuddyClient title={title} />
+      <ThrashBuddyClient title={title} githubUrl={github} />
       <Footer />
     </>
   );

--- a/web-buddy/src/app/tools/toolPage.ts
+++ b/web-buddy/src/app/tools/toolPage.ts
@@ -11,6 +11,7 @@ export function getToolPageData(slug: string) {
   const title = tool?.name ?? "";
   const description = tool?.description ?? "";
   const image = tool?.previewImage;
+  const github = tool?.github ?? "";
   const titleFull = tool?.tagline ? `${title} - ${tool.tagline}` : title;
 
   const metadata = createMetadata({
@@ -33,5 +34,5 @@ export function getToolPageData(slug: string) {
     ...(image ? { image } : {}),
   };
 
-  return { title, metadata, jsonLd, jsonLdId: `jsonld-${slug}` };
+  return { title, github, metadata, jsonLd, jsonLdId: `jsonld-${slug}` };
 }

--- a/web-buddy/tests/tool-github-link.spec.ts
+++ b/web-buddy/tests/tool-github-link.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+const readyTools = tools.filter((tool) => tool.status === "ready");
+
+for (const tool of readyTools) {
+  test(`/tools/${tool.slug} repo link matches tools.ts github value`, async ({
+    page,
+  }) => {
+    await page.goto(`/tools/${tool.slug}`);
+
+    const repoLink = page.locator(`a[href="${tool.github}"]`).first();
+    await expect(repoLink).toBeVisible();
+  });
+}


### PR DESCRIPTION
## Summary
- Every tool record in `tools.ts` defines `github: \`\${GITHUB_URL}/...\``, but no call site consumed it — each ready tool page hardcoded its repo link as a string literal instead, bypassing both the field and the `GITHUB_URL` constant it's built from
- Renaming a repo or the org required hunting string literals across five files

## Changes
- `getToolPageData` (`toolPage.ts`) now also returns the tool's `github` URL
- Each `page.tsx` passes it to its client component as `githubUrl`
- Each client's `DescriptionSection` (or inline link, for `gamegallerybuddy`) now uses `githubUrl` instead of a hardcoded href
- Added `tests/tool-github-link.spec.ts` asserting each ready tool page's repo link matches its `tools.ts` `github` value

Out of scope (tracked separately): the raw GitHub URL in `ridemergebuddy`'s screenshot caption text (#442).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (78/78 passing)

Fixes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)