### PR TITLE
fix: add github-actions ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- `dependabot.yml` listed only the `npm` ecosystem, so action version pins (`.github/workflows/*.yml`) would rot silently despite an otherwise aggressive auto-update setup

## Changes
- Added a `github-actions` ecosystem entry (directory `/`) alongside the existing `npm` entry, same daily schedule and 7-day cooldown

Note: this issue also flagged `actions/checkout@v3` and a dead-weight checkout step in `auto-merge.yml`, but that workflow no longer has a checkout step at all (removed in an earlier change) — verified via `git log` and the current file. Nothing left to do there.

## Test plan
- [x] `pre-commit run check-yaml --files .github/dependabot.yml`
- [x] `pre-commit run zizmor --files .github/dependabot.yml .github/workflows/*.yml`

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)