### PR TITLE
fix: drop redundant playwright devDependency

### DIFF
--- a/web-buddy/package-lock.json
+++ b/web-buddy/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web-buddy",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "next": "16.2.10",
         "postcss": "^8.5.16",
@@ -21,10 +22,12 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
-        "playwright": "^1.61.0",
         "serve": "^14.2.6",
         "tailwindcss": "^4.3.2",
         "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/web-buddy/package.json
+++ b/web-buddy/package.json
@@ -30,7 +30,6 @@
     "eslint-config-next": "16.2.10",
     "tailwindcss": "^4.3.2",
     "typescript": "6.0.3",
-    "playwright": "^1.61.0",
     "@playwright/test": "^1.61.1",
     "serve": "^14.2.6"
   }


### PR DESCRIPTION
## Summary
- Both `"playwright": "^1.61.0"` and `"@playwright/test": "^1.61.1"` were declared in devDependencies, but the only imports anywhere (specs + config) are from `@playwright/test`, which already depends on an exact-pinned `playwright`
- With daily Dependabot, each release produced two PRs for one logical dependency, and a solo `playwright` bump could yield a mismatched nested browser revision (`Executable doesn't exist` failures)

## Changes
- Removed `"playwright"` from `package.json` devDependencies; `@playwright/test` (and its own `playwright` CLI bin) remains
- Regenerated `package-lock.json`

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (73/73 passing)
- [x] `npx playwright --version` still resolves via `@playwright/test`'s own bin

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)