### PR TITLE
fix: cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,24 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Build Next.js application
         run: npm run build


### PR DESCRIPTION
## Summary
- `npx playwright install --with-deps chromium` (~150 MB download) ran on every push and every daily Dependabot PR with no `actions/cache` step — only the npm cache via `setup-node` existed

## Changes
- Added a step reading the installed `@playwright/test` version from `package-lock.json`
- Cache `~/.cache/ms-playwright` keyed on `${{ runner.os }}-playwright-<version>`
- On a cache hit, skip the browser download and only run `playwright install-deps chromium` (OS deps still need installing on a fresh runner)

## Test plan
- [x] `pre-commit run check-yaml zizmor editorconfig-checker trailing-whitespace end-of-file-fixer --files .github/workflows/ci.yml`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test` (73/73 passing)
- [ ] Confirm cache hit + reduced run time on the next CI run for this PR

Fixes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)