### PR TITLE
fix: add a mobile-viewport Playwright project

### DIFF
--- a/web-buddy/playwright.config.ts
+++ b/web-buddy/playwright.config.ts
@@ -23,5 +23,10 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 7"] },
+      testMatch: /mobile-.*\.spec\.ts/,
+    },
   ],
 });

--- a/web-buddy/tests/mobile-nav.spec.ts
+++ b/web-buddy/tests/mobile-nav.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+const firstPageOneTool = tools[0];
+
+test.describe("mobile viewport: nav and pagination stay usable", () => {
+  test("header nav links are visible", async ({ page }) => {
+    await page.goto("/");
+
+    const nav = page.getByRole("navigation").first();
+    await expect(nav.getByRole("link", { name: "Tools" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "About" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "GitHub" })).toBeVisible();
+  });
+
+  test("tools pagination is visible and usable", async ({ page }) => {
+    await page.goto("/tools");
+
+    const firstPageLink = page.getByRole("link", {
+      name: new RegExp(firstPageOneTool.name),
+    });
+    await expect(firstPageLink).toBeVisible();
+
+    const pageTwo = page.getByRole("button", { name: "2" });
+    await expect(pageTwo).toBeVisible();
+    await pageTwo.click();
+
+    await expect(firstPageLink).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- The Playwright config's only project was Desktop Chrome. The UI leans on responsive breakpoints, a fixed header/footer, and content conditionally hidden below `md`, yet nothing ever ran at a mobile viewport — a breakpoint regression hiding nav or pagination on small screens could ship undetected

## Changes
- Added a `mobile` project using `devices["Pixel 7"]` (still Chromium — no extra browser engine download)
- Scoped it via `testMatch: /mobile-.*\.spec\.ts/` so it only runs mobile-specific specs rather than duplicating the entire suite at a second viewport
- Added `tests/mobile-nav.spec.ts` asserting the header nav links and tools pagination stay visible and usable at that viewport

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `CI=true npx playwright test` (77/77 passing, serial workers matching CI)

Note: a local fully-parallel run occasionally flakes on the pre-existing `tests/reduced-motion.spec.ts` canvas-pixel assertion under worker contention — unrelated to this change and doesn't reproduce with CI's `workers: 1`.

Fixes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)