### PR TITLE
fix: correct Karma Buddy slug typo (karmabudddy -> karmabuddy)

### DIFF
--- a/web-buddy/src/app/tools/tools.ts
+++ b/web-buddy/src/app/tools/tools.ts
@@ -108,7 +108,7 @@ export const tools = [
     status: "coming_soon",
   },
   {
-    slug: "karmabudddy",
+    slug: "karmabuddy",
     name: "Karma Buddy",
     description:
       "Track your karma points with a fun and engaging app. Compete with friends and see who has the highest karma score.",

--- a/web-buddy/tests/tool-slugs.spec.ts
+++ b/web-buddy/tests/tool-slugs.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+import { tools } from "../src/app/tools/tools";
+
+for (const tool of tools) {
+  test(`${tool.name} slug matches its name (lowercased, spaces stripped)`, () => {
+    const expectedSlug = tool.name.toLowerCase().replace(/\s+/g, "");
+    expect(tool.slug).toBe(expectedSlug);
+  });
+}


### PR DESCRIPTION
## Summary
- `tools.ts` has `slug: "karmabudddy"` (three d's). Harmless today since coming-soon cards render as unclickable divs, but the slug drives the future route, card link, sitemap entry, and canonical URL — the moment status flips to `ready`, the grid would link to `/tools/karmabudddy` against a page directory naturally created as `karmabuddy`

## Changes
- Fixed the slug to `karmabuddy`
- Added `tests/tool-slugs.spec.ts` asserting every tool's slug equals its name lowercased with spaces stripped — catches this class of typo permanently rather than just this one instance

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `CI=true npx playwright test` (82/82 passing)

Fixes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)