### PR TITLE
fix: replace nonexistent text-neutral-750/150 with real Tailwind shades

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -86,7 +86,7 @@ function Hero() {
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-base sm:text-lg md:text-xl text-neutral-750 dark:text-neutral-150 mb-6 md:mb-8">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-base sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-6 md:mb-8">
         {SITE_DESCRIPTION}
       </h2>
 

--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -37,7 +37,7 @@ export default function ToolGrid() {
         <h1 className="text-center relative z-10 text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
           The Buddy Compendium
         </h1>
-        <h2 className="text-center relative z-10 max-w-2xl mx-auto text-lg sm:text-xl text-neutral-750 dark:text-neutral-150 mb-4 md:mb-8">
+        <h2 className="text-center relative z-10 max-w-2xl mx-auto text-lg sm:text-xl text-neutral-700 dark:text-neutral-200 mb-4 md:mb-8">
           Blending quirky charm with real-world usefulness for {"'everybuddy'"}
         </h2>
         <br />

--- a/web-buddy/tests/subtitle-contrast.spec.ts
+++ b/web-buddy/tests/subtitle-contrast.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import { contrastRatio } from "./utils/contrast";
+
+const cases = [
+  { path: "/", label: "homepage hero subtitle" },
+  { path: "/tools", label: "tools hub subtitle" },
+];
+
+test.describe("subtitle text contrast", () => {
+  for (const { path, label } of cases) {
+    for (const colorScheme of ["light", "dark"] as const) {
+      test(`${label} meets WCAG AA (4.5:1) in ${colorScheme} mode`, async ({
+        page,
+      }) => {
+        await page.emulateMedia({ colorScheme });
+        await page.goto(path);
+
+        const subtitle = page.locator("h2").first();
+        const { color, bg, probeColor } = await subtitle.evaluate((node) => {
+          // A muted-gray utility class must actually resolve to a real
+          // Tailwind color, not silently fall back to the inherited
+          // black/white foreground (which happens to also pass AA,
+          // masking a typo'd/nonexistent class name).
+          const probe = document.createElement("span");
+          probe.className = "text-neutral-700 dark:text-neutral-200";
+          document.body.appendChild(probe);
+          const probeColor = getComputedStyle(probe).color;
+          probe.remove();
+
+          const style = getComputedStyle(node);
+          return {
+            color: style.color,
+            bg: getComputedStyle(document.body).backgroundColor,
+            probeColor,
+          };
+        });
+
+        expect(color).toBe(probeColor);
+        expect(await contrastRatio(page, bg, color)).toBeGreaterThanOrEqual(
+          4.5
+        );
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- `neutral-750` and `neutral-150` aren't tokens in Tailwind 4's default palette and no `@theme` block adds them, so Tailwind silently generated no CSS for `text-neutral-750 dark:text-neutral-150`
- The homepage hero and `/tools` subtitles rendered in the full-contrast inherited foreground instead of the intended muted gray — readable by accident, but dead classes documenting an intent neither page implemented

## Changes
- Replaced with `text-neutral-700 dark:text-neutral-200` in `TerminalIntro.tsx` and `ToolGrid.tsx`, which resolve to real colors and still clear WCAG AA (4.5:1)
- Added `tests/subtitle-contrast.spec.ts`

A plain contrast-ratio check turns out not to catch this bug class — the inherited black/white fallback also happens to pass AA (noted in the issue itself). So the test compares each subtitle's computed color against a probe element carrying the intended class list; verified red against the original `-750`/`-150` classes (color mismatch) and green against the fix, in addition to the contrast assertion.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `CI=true npx playwright test` (77/77 passing)
- [x] Manually reverted the fix locally and confirmed the new test fails (red), then restored it (green)

Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)