### PR TITLE
fix: reserve a stable scrollbar gutter to stop header/footer nudging on nav

### DIFF
--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -31,6 +31,17 @@ body {
   overflow-x: hidden;
 }
 
+/* Reserve a stable scrollbar gutter regardless of whether a given page
+   actually needs to scroll. Without this, navigating between a short page
+   (no scrollbar) and a tall one (scrollbar present) shifts the effective
+   viewport width on platforms/browsers with classic reserved-space
+   scrollbars (common on Windows/Linux, or macOS set to always show
+   scrollbars) — visibly nudging the fixed header/nav and footer, which are
+   centered via mx-auto. */
+html {
+  scrollbar-gutter: stable;
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;

--- a/web-buddy/tests/scrollbar-gutter.spec.ts
+++ b/web-buddy/tests/scrollbar-gutter.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+// Regression coverage for a layout shift users saw when navigating between
+// pages of different content height: without a reserved scrollbar gutter,
+// platforms/browsers with classic (non-overlay) scrollbars change the
+// effective viewport width depending on whether the current page needs to
+// scroll, nudging the centered fixed header/footer sideways.
+test("html reserves a stable scrollbar gutter", async ({ page }) => {
+  await page.goto("/");
+
+  const scrollbarGutter = await page.evaluate(
+    () => getComputedStyle(document.documentElement).scrollbarGutter
+  );
+
+  expect(scrollbarGutter).toContain("stable");
+});


### PR DESCRIPTION
## Summary
- Navigating between pages of different content height (e.g. /tools to a tool detail page) visibly shifted the fixed header and footer sideways
- Root cause: on platforms/browsers with classic (non-overlay) scrollbars — common on Windows/Linux, or macOS set to always show scrollbars — whether a given page needs to scroll changes the effective layout viewport width, which nudges anything centered via \`mx-auto\` (including the fixed header/nav and footer)

## Changes
- Added \`scrollbar-gutter: stable\` to \`html\` in \`globals.css\`, reserving consistent gutter space regardless of whether the current page actually scrolls — the standard mitigation for this exact symptom
- Added \`tests/scrollbar-gutter.spec.ts\` asserting the property is applied

## A note on verification
I could not reproduce the actual pixel shift in this environment's headless Chromium — \`window.innerWidth\` stayed constant across a scrollbar/no-scrollbar navigation pair at multiple viewport sizes, suggesting this Chromium build uses overlay-style scrollbars that don't reserve layout space. So rather than a visual pixel-shift test (which can't reproduce here), the test directly asserts the CSS property. The fix itself is still correct, safe, and the standard remedy for the reported symptom on browsers/platforms that do reserve scrollbar space.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [x] \`CI=true npx playwright test\` (125/125 passing)

Fixes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)