### PR TITLE
fix: restore gentle scroll-snap on homepage manifesto sections

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -50,7 +50,7 @@ function ManifestoSection({
   return (
     <section
       ref={ref}
-      className={`min-h-screen flex flex-col justify-center items-center text-center px-6 py-10 ${bg}`}
+      className={`min-h-screen snap-start flex flex-col justify-center items-center text-center px-6 py-10 ${bg}`}
     >
       <div className={`text-6xl mb-6 ${revealClass}`} style={fadeStyle(inView, 0, 20)}>
         {emoji}
@@ -77,7 +77,7 @@ function CallToActionSection() {
   return (
     <section
       ref={ref}
-      className="h-screen flex flex-col justify-center items-center text-center p-10 bg-lime-100 dark:bg-lime-900"
+      className="h-screen snap-start flex flex-col justify-center items-center text-center p-10 bg-lime-100 dark:bg-lime-900"
     >
       <div
         className={`text-xl sm:text-2xl mb-6 ${inView ? "fade-in-up" : "opacity-0"}`}

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -32,8 +32,8 @@ export default function HomePage() {
     <>
       <JsonLd id="jsonld-home" data={jsonLd} />
       <Header />
-      <main className="text-black dark:text-white overflow-x-hidden">
-        <section className="min-h-screen">
+      <main className="text-black dark:text-white overflow-x-hidden snap-y snap-proximity motion-reduce:snap-none">
+        <section className="min-h-screen snap-start">
           <CirclesBackground variant="page2" />
           <TerminalIntro />
         </section>

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+// Restores gentle scroll-snap on the homepage manifesto (a small scroll
+// nudge completes to reveal the full next section) without reintroducing
+// the scroll-jacking/keyboard-trap problem a prior fix removed: this uses
+// scroll-snap-type on the normal document flow (no nested overflow
+// container) with "proximity", not "mandatory", so free scrolling and
+// keyboard navigation are unaffected — see homepage.spec.ts's existing
+// "reachable via keyboard scrolling" coverage for that.
+test.describe("homepage scroll snap", () => {
+  test("main uses proximity (not mandatory) snap, with matching snap-start targets", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // "proximity" is the spec-default strictness when omitted from the
+    // axis-only value, so Chromium's computed style canonicalizes
+    // "y proximity" down to just "y" — this asserts the y-axis is set and,
+    // crucially, that it's NOT "y mandatory" (which would reintroduce the
+    // scroll-jacking #413 removed).
+    const main = page.locator("main");
+    await expect(main).toHaveCSS("scroll-snap-type", "y");
+
+    const snapTargets = page.locator(
+      "main > section, main > div > section"
+    );
+    const count = await snapTargets.count();
+    expect(count).toBeGreaterThanOrEqual(5);
+
+    for (let i = 0; i < count; i++) {
+      await expect(snapTargets.nth(i)).toHaveCSS(
+        "scroll-snap-align",
+        "start"
+      );
+    }
+  });
+
+  test("snap is disabled under prefers-reduced-motion", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    const main = page.locator("main");
+    await expect(main).toHaveCSS("scroll-snap-type", "none");
+  });
+});


### PR DESCRIPTION
## Summary
- A prior fix for scroll-jacking/keyboard-trapping (#413) removed scroll-snap entirely — it dropped the nested \`h-screen overflow-y-scroll snap-mandatory\` container in favor of plain document scrolling
- That fixed the hijacking and keyboard-trap problems, but as a side effect a small scroll nudge no longer completes to reveal the full next section — every section-sized scroll now requires manually scrolling the exact distance, which read as the scrolling feeling less "snappy"

## Changes
- Restored snapping via \`scroll-snap-type: y proximity\` directly on the normal document-scrolling \`<main>\` — no nested overflow container, so keyboard/PageDown/Tab navigation is unaffected (verified against the existing \`homepage.spec.ts\` "reachable via keyboard scrolling" test)
- Added \`scroll-snap-align: start\` to each section (\`TerminalIntro\`'s wrapper + all \`ManifestoScroll\` sections)
- Used \`proximity\`, not \`mandatory\`: scrolling can still rest anywhere; it only nudges into alignment near a snap point, avoiding the trapping behavior #413 reported
- Disabled under \`prefers-reduced-motion\` via \`motion-reduce:snap-none\`, matching this codebase's existing pattern for motion-sensitive users
- Added \`tests/scroll-snap.spec.ts\`

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [x] \`CI=true npx playwright test\` (139/139 passing, including existing keyboard-scroll and reduced-motion coverage)

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)