### PR TITLE
fix: remove visible "In progress" label from coming-soon cards

### DIFF
--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -107,12 +107,6 @@ export default function ToolGrid() {
                     </span>
                   ))}
                 </div>
-
-                {!isReady && (
-                  <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mt-4 underline group-hover:text-black dark:group-hover:text-white">
-                    In progress — view on GitHub
-                  </p>
-                )}
               </>
             );
 
@@ -133,6 +127,7 @@ export default function ToolGrid() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className={cardClasses}
+                  aria-label={`${tool.name} — in progress, view repository on GitHub`}
                 >
                   {cardInner}
                 </a>


### PR DESCRIPTION
## Summary
- The "In progress — view on GitHub" text label added to coming-soon cards (#441) wrapped differently per card, breaking the grid's layout alignment

## Changes
- Removed the visible \`<p>\` label. The whole card is already an \`<a href={tool.github}>\`, so clicking still opens the repo on GitHub — no behavior change
- Added an \`aria-label\` on the link itself instead, preserving the "in progress, view repository on GitHub" context for screen reader users without any visible/layout-affecting text

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [x] \`CI=true npx playwright test\` (154/154 passing)
- [x] Screenshot-verified the layout no longer breaks on /tools page 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)