### PR TITLE
feat: give the homepage manifesto a gradient morph, center-pause snap, and progressive reveal

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { CSSProperties } from "react";
 import { useInView } from "../hooks/useInView";
 
 const ideas = [
@@ -8,63 +7,38 @@ const ideas = [
     emoji: "🧸",
     title: "Software can be useful and weird",
     body: `Every Buddy is designed to solve a real problem, but always with a twist. Whether it's merging GPS tracks or generating board game wallpapers, the functionality comes first. If the interface makes you smile, it’s a bonus. We believe that utility doesn't have to be boring. Playful design can spark joy and curiosity, even in the most mundane tasks. It's about making tools that work well and feel good to use.`,
-    bg: "bg-red-100 dark:bg-red-900",
   },
   {
     emoji: "🎛️",
     title: "Fueled by hype, grounded in curiosity",
     body: `This is a playground for whatever tech looks shiny today. Next.js, Tailwind, k6, Docker, AWS, even Groovy. If it's fun to build with, it’s fair game. These tools exist to experiment, not to optimize. The stack changes when the mood does. It’s not about chasing trends for the sake of relevance. It’s about exploring what’s possible, learning by doing, and embracing the chaos of modern development. Curiosity drives everything here.`,
-    bg: "bg-yellow-100 dark:bg-yellow-900",
   },
   {
     emoji: "📦",
     title: "Fork it, run it, improve it",
     body: `All tools are fully open source and self-contained. You can clone them, spin them up locally, or deploy in the cloud with minimal effort. There is no lock-in, no tracking, and no nonsense. Every Buddy is yours to use or change as you like. Contributions are welcome, and experimentation is encouraged. Whether you're fixing a bug, adding a feature, or just poking around, you're part of the process. The code is yours. Make it better or make it weird.`,
-    bg: "bg-sky-100 dark:bg-sky-900",
   },
   {
     emoji: "🚀",
     title: "This is a hobby project",
     body: `No big team, no investors, no corporate goals. Just some developers shipping tools out of curiosity and frustration. Some ideas are polished, others are experimental. If something breaks or feels unfinished, it’s probably because it was released too early. That’s part of the fun. This space is intentionally imperfect. It's a sandbox for ideas that might not fit anywhere else. It’s about freedom, creativity, and the joy of building without pressure.`,
-    bg: "bg-rose-100 dark:bg-rose-900",
   },
 ];
 
-function fadeStyle(inView: boolean, delay: number, y: number): CSSProperties {
-  return {
-    animationDuration: "0.5s",
-    animationDelay: inView ? `${delay}s` : "0s",
-    "--fade-y": `${y}px`,
-  } as CSSProperties;
-}
-
-function ManifestoSection({
-  emoji,
-  title,
-  body,
-  bg,
-}: (typeof ideas)[number]) {
-  const { ref, inView } = useInView<HTMLElement>({ threshold: 0.3 });
-  const revealClass = inView ? "fade-in-up" : "opacity-0";
+function ManifestoSection({ emoji, title, body }: (typeof ideas)[number]) {
+  // once: false — re-reveal each time this section becomes the active one
+  // again, matching the center scroll-snap pause (a viewer scrolling back
+  // up should see the same reveal, not a page that's already "used up").
+  const { ref, inView } = useInView<HTMLElement>({ threshold: 0.55 }, false);
 
   return (
     <section
       ref={ref}
-      className={`min-h-screen snap-start flex flex-col justify-center items-center text-center px-6 py-10 ${bg}`}
+      className={`manifesto-section min-h-screen snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${inView ? "in-view" : ""}`}
     >
-      <div className={`text-6xl mb-6 ${revealClass}`} style={fadeStyle(inView, 0, 20)}>
-        {emoji}
-      </div>
-      <h2
-        className={`text-2xl sm:text-3xl font-bold mb-4 ${revealClass}`}
-        style={fadeStyle(inView, 0.2, 20)}
-      >
-        {title}
-      </h2>
-      <p
-        className={`max-w-xl text-base sm:text-lg text-gray-800 dark:text-gray-200 ${revealClass}`}
-        style={fadeStyle(inView, 0.4, 10)}
-      >
+      <div className="manifesto-emoji text-6xl mb-6">{emoji}</div>
+      <h2 className="text-2xl sm:text-3xl font-bold mb-4">{title}</h2>
+      <p className="max-w-xl text-base sm:text-lg text-gray-800 dark:text-gray-200">
         {body}
       </p>
     </section>
@@ -72,17 +46,14 @@ function ManifestoSection({
 }
 
 function CallToActionSection() {
-  const { ref, inView } = useInView<HTMLElement>({ threshold: 0.3 });
+  const { ref, inView } = useInView<HTMLElement>({ threshold: 0.55 }, false);
 
   return (
     <section
       ref={ref}
-      className="h-screen snap-start flex flex-col justify-center items-center text-center p-10 bg-lime-100 dark:bg-lime-900"
+      className={`manifesto-section h-screen snap-center flex flex-col justify-center items-center text-center p-10 ${inView ? "in-view" : ""}`}
     >
-      <div
-        className={`text-xl sm:text-2xl mb-6 ${inView ? "fade-in-up" : "opacity-0"}`}
-        style={{ animationDuration: "1s", "--fade-y": "0px" } as CSSProperties}
-      >
+      <div className="manifesto-cta-text text-xl sm:text-2xl mb-6">
         Explore the tools. Adopt a Buddy.
       </div>
       <a
@@ -98,11 +69,11 @@ function CallToActionSection() {
 
 export default function ManifestoScroll() {
   return (
-    <>
+    <div className="manifesto-gradient">
       {ideas.map((idea) => (
         <ManifestoSection key={idea.title} {...idea} />
       ))}
       <CallToActionSection />
-    </>
+    </div>
   );
 }

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -3,6 +3,14 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --manifesto-gradient: linear-gradient(
+    180deg,
+    #fee2e2 0%,
+    #fef9c3 25%,
+    #e0f2fe 50%,
+    #ffe4e6 75%,
+    #ecfccb 100%
+  );
 }
 
 @theme inline {
@@ -17,6 +25,14 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --manifesto-gradient: linear-gradient(
+      180deg,
+      #7f1d1d 0%,
+      #713f12 25%,
+      #0c4a6e 50%,
+      #4c0519 75%,
+      #365314 100%
+    );
   }
 }
 
@@ -64,5 +80,96 @@ html {
     animation: none;
     opacity: 1;
     transform: none;
+  }
+}
+
+/* Homepage manifesto scroll effects: one continuous gradient painted
+   behind all manifesto sections (replacing hard per-section color cuts),
+   plus a progressive reveal driven by useInView (JS/IntersectionObserver
+   + CSS transition) rather than animation-timeline — the latter is newer
+   CSS that can silently no-op in some browsers, which a purely decorative
+   reveal effect shouldn't risk. */
+.manifesto-gradient {
+  background-image: var(--manifesto-gradient);
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+}
+
+.manifesto-section h2,
+.manifesto-section p {
+  opacity: 0;
+  translate: 0 26px;
+  scale: 0.94;
+  transition:
+    opacity 0.55s cubic-bezier(0.16, 1, 0.3, 1),
+    translate 0.55s cubic-bezier(0.16, 1, 0.3, 1),
+    scale 0.55s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.manifesto-section.in-view h2 {
+  opacity: 1;
+  translate: 0 0;
+  scale: 1;
+  transition-delay: 0.06s;
+}
+.manifesto-section.in-view p {
+  opacity: 1;
+  translate: 0 0;
+  scale: 1;
+  transition-delay: 0.16s;
+}
+
+.manifesto-emoji {
+  opacity: 0;
+  transition: opacity 0.5s ease-out;
+}
+.manifesto-section.in-view .manifesto-emoji {
+  opacity: 1;
+}
+
+.manifesto-cta-text {
+  opacity: 0;
+  translate: 0 26px;
+  scale: 0.94;
+  transition:
+    opacity 0.55s cubic-bezier(0.16, 1, 0.3, 1),
+    translate 0.55s cubic-bezier(0.16, 1, 0.3, 1),
+    scale 0.55s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.manifesto-section.in-view .manifesto-cta-text {
+  opacity: 1;
+  translate: 0 0;
+  scale: 1;
+}
+
+/* Parallax drift on the manifesto emoji only — decorative, continuous
+   motion at a different rate than the (steady, readable) text. Only
+   touches `translate`, so it can't fight the opacity transition above.
+   Purely an enhancement: degrades to a static emoji if unsupported. */
+@supports (animation-timeline: view()) {
+  @keyframes manifesto-emoji-drift {
+    from {
+      translate: 0 56px;
+    }
+    to {
+      translate: 0 -56px;
+    }
+  }
+  .manifesto-emoji {
+    animation: manifesto-emoji-drift linear both;
+    animation-timeline: view();
+    animation-range: cover 0% cover 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .manifesto-emoji,
+  .manifesto-cta-text,
+  .manifesto-section h2,
+  .manifesto-section p {
+    transition: none !important;
+    animation: none !important;
+    opacity: 1 !important;
+    translate: 0 !important;
+    scale: 1 !important;
   }
 }

--- a/web-buddy/src/app/hooks/useInView.ts
+++ b/web-buddy/src/app/hooks/useInView.ts
@@ -2,10 +2,14 @@
 
 import { useEffect, useRef, useState } from "react";
 
-// Mirrors framer-motion's whileInView + viewport={{ once: true }}: reveal an
-// element the first time it scrolls into the viewport, then stop observing.
+// Mirrors framer-motion's whileInView + viewport={{ once }}: by default,
+// reveal an element the first time it scrolls into the viewport and stop
+// observing (once: true). Pass once: false to keep tracking and toggle
+// inView both ways — e.g. content that should re-reveal each time a
+// scroll-snap section becomes active again.
 export function useInView<T extends HTMLElement>(
-  options?: IntersectionObserverInit
+  options?: IntersectionObserverInit,
+  once: boolean = true
 ) {
   const ref = useRef<T>(null);
   const [inView, setInView] = useState(false);
@@ -15,8 +19,8 @@ export function useInView<T extends HTMLElement>(
     if (!el) return;
 
     const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setInView(true);
+      setInView(entry.isIntersecting);
+      if (entry.isIntersecting && once) {
         observer.disconnect();
       }
     }, options);

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function HomePage() {
       <JsonLd id="jsonld-home" data={jsonLd} />
       <Header />
       <main className="text-black dark:text-white overflow-x-hidden snap-y snap-proximity motion-reduce:snap-none">
-        <section className="min-h-screen snap-start">
+        <section className="min-h-screen snap-center">
           <CirclesBackground variant="home" />
           <TerminalIntro />
         </section>

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("homepage manifesto scroll effects", () => {
+  test("manifesto sections sit on one continuous gradient, not hard-cut colors", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const gradientWrap = page.locator(".manifesto-gradient");
+    await expect(gradientWrap).toBeAttached();
+    const backgroundImage = await gradientWrap.evaluate(
+      (el) => getComputedStyle(el).backgroundImage
+    );
+    expect(backgroundImage).toContain("gradient");
+  });
+
+  test("a manifesto section reveals its heading as it scrolls into view", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const heading = page.getByRole("heading", {
+      name: "This is a hobby project",
+    });
+    await heading.scrollIntoViewIfNeeded();
+    // Allow the CSS transition to complete.
+    await expect(heading).toHaveCSS("opacity", "1", { timeout: 2000 });
+  });
+
+  test("reveal is disabled (always visible, no transition) under prefers-reduced-motion", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    const heading = page.getByRole("heading", {
+      name: "Software can be useful and weird",
+    });
+    await expect(heading).toHaveCSS("opacity", "1");
+  });
+});

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -8,7 +8,7 @@ import { test, expect } from "@playwright/test";
 // keyboard navigation are unaffected — see homepage.spec.ts's existing
 // "reachable via keyboard scrolling" coverage for that.
 test.describe("homepage scroll snap", () => {
-  test("main uses proximity (not mandatory) snap, with matching snap-start targets", async ({
+  test("main uses proximity (not mandatory) snap, with matching snap-center targets", async ({
     page,
   }) => {
     await page.goto("/");
@@ -30,7 +30,7 @@ test.describe("homepage scroll snap", () => {
     for (let i = 0; i < count; i++) {
       await expect(snapTargets.nth(i)).toHaveCSS(
         "scroll-snap-align",
-        "start"
+        "center"
       );
     }
   });


### PR DESCRIPTION
## Summary
The homepage manifesto sections had hard-cut background colors and a one-shot fade-in animation with a fixed timer. Prototyped several interactive demos before landing on this combination.

## Changes
- **Gradient morph**: one continuous gradient (\`--manifesto-gradient\`, light+dark) painted behind all manifesto sections, replacing the per-section \`bg-red-100\`/\`bg-yellow-100\`/etc. Tailwind classes
- **Center-pause snap**: \`scroll-snap-align\` switched from \`start\` to \`center\` on every section (intro + all four manifesto ideas + CTA) — still \`proximity\` strictness, so it eases to a centered pause without trapping scroll the way #413's \`mandatory\` snap did
- **Progressive reveal**: heading/paragraph/emoji now reveal via \`useInView\` + a CSS transition (opacity/translate/scale), timed to complete right around where the snap settles, instead of a fixed-duration animation keyed only to first appearance
  - \`useInView\` gained an optional \`once\` param (default \`true\`, unchanged for the existing \`ToolScreenshots\` caller) so this reveal can replay each time a section becomes active again, matching the new snap-pause rhythm
- **Emoji parallax**: subtle drift via \`animation-timeline: view()\` — a pure CSS enhancement gated behind \`@supports\`, degrading to a static emoji if unsupported, so nothing load-bearing depends on it
- All motion respects \`prefers-reduced-motion\` (snap disabled, reveal always-visible with no transition, drift removed)

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [x] \`CI=true npx playwright test\` (157/157 passing, including updated \`scroll-snap.spec.ts\` and new \`manifesto-scroll-effects.spec.ts\`)
- [x] Verified the existing "reachable via keyboard scrolling" and reduced-motion coverage still pass unchanged
- [x] Screenshot-verified the real page: gradient renders correctly, CTA reveals on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)