### PR TITLE
docs: make README lead with the actual tool catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
-# nobuddyorg.github.io
+# nobuddy.org
 
-![nobuddy logo large](web-buddy/public/nobuddy_logo.webp)
+[![Deploy Pages](https://github.com/nobuddyorg/nobuddyorg.github.io/actions/workflows/pages-deploy.yml/badge.svg)](https://github.com/nobuddyorg/nobuddyorg.github.io/actions/workflows/pages-deploy.yml)
+[![CI](https://github.com/nobuddyorg/nobuddyorg.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/nobuddyorg/nobuddyorg.github.io/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-This repository contains the static pages of nobuddyorg, served at
-[nobuddy.org](https://nobuddy.org). The site is a Next.js app in
-[`web-buddy/`](web-buddy/), statically exported and deployed to GitHub Pages.
+![nobuddy logo](web-buddy/public/nobuddy_logo.webp)
+
+**Creative tools for nerds.** This repo is the portal site for
+[nobuddy.org](https://nobuddy.org) — the front door to a growing collection
+of small, self-contained "Buddy" apps, each living in its own repo under the
+[nobuddyorg](https://github.com/nobuddyorg) org. No corporate roadmap, no
+investors: just tools built out of curiosity, shipped when they're fun, and
+fully open source.
+
+The site itself is a Next.js app in [`web-buddy/`](web-buddy/), statically
+exported and deployed to GitHub Pages.
+
+## The Buddies
+
+| Tool | What it does | Stack |
+| --- | --- | --- |
+| [Procrastination Buddy](https://github.com/nobuddyorg/ProcrastinationBuddy) | Delightfully useless tasks to help you avoid productivity | Streamlit, Ollama AI, Docker |
+| [Thrash Buddy](https://github.com/nobuddyorg/ThrashBuddy) | Load-test APIs at scale | k6, Grafana, Prometheus, AWS EKS |
+| [Game Gallery Buddy](https://github.com/nobuddyorg/GameGalleryBuddy) | Generates a wallpaper from a BoardGameGeek collection | Groovy, Spring Boot |
+| [Collection Buddy](https://github.com/nobuddyorg/CollectionBuddy) | Catalog and track stamps, coins, or any collectibles | Next.js, Supabase, Tailwind |
+| [Ride Merge Buddy](https://github.com/nobuddyorg/RideMergeBuddy) | Merges GPX tracks from multiple cycling sessions | Angular |
+| Fair Buddy *(coming soon)* | Split costs fairly within a group | Java, DynamoDB |
+| Power Trail Buddy *(coming soon)* | Find and visualize geocaching power trails | Next.js |
+| Karma Buddy *(coming soon)* | Track karma points, compete with friends | Java, Hugging Face |
+| Peek Buddy *(coming soon)* | Watches folders and logs filesystem changes | Electron |
+| Bike Buddy *(coming soon)* | GPX heatmaps and ride memories | Azure Functions, Cosmos DB |
+
+Full descriptions and live links: [nobuddy.org/tools](https://nobuddy.org/tools).
+
+![Tools & Libraries Overview](logo_tools_libs_small.png)
 
 ## Development
 
@@ -13,7 +42,7 @@ Prerequisites: Node 22 (see `web-buddy/.nvmrc`).
 ```bash
 cd web-buddy
 npm ci
-npm run dev       # starts the dev server at http://localhost:3000
+npm run dev       # dev server at http://localhost:3000
 ```
 
 Other useful commands (run from `web-buddy/`):
@@ -39,8 +68,8 @@ From the repo root, `./build.sh` does a full local sanity check: a clean
 Pushes to `main` automatically build and deploy the site to
 [nobuddy.org](https://nobuddy.org) via `.github/workflows/pages-deploy.yml`.
 
-## Tools & Libraries Overview
+## Contributing
 
-To give a quick overview of the tools and libraries used in this repository, a montage with the corresponding logos was created.
-
-![Tools & Libraries Overview](logo_tools_libs_small.png)
+Every Buddy is a normal open-source repo: fork it, run it locally, send a
+PR. This portal repo follows the same rules — see the workflows in
+[`.github/workflows/`](.github/workflows/) for what CI checks on every push.


### PR DESCRIPTION
## Summary
The README was a bare dev-setup stub — no mention of what any of the "Buddy" tools actually are, and a "Tools & Libraries Overview" section that only showed an image montage without naming anything.

## Changes
- New intro explaining what nobuddyorg/nobuddy.org actually is (portal site for a collection of independent tool repos)
- "The Buddies" table sourced from the real catalog in `web-buddy/src/app/tools/tools.ts` — name, what it does, stack, and a link to each tool's repo
- CI / Deploy Pages / License badges
- Trimmed a couple of stale phrasings, added a short Contributing section

No code changes — README/docs only.

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)