### PR TITLE
chore: extract ToolClientPage to remove duplicated tool-page boilerplate

### DIFF
--- a/web-buddy/src/app/components/ToolClientPage.tsx
+++ b/web-buddy/src/app/components/ToolClientPage.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import ToolPageShell from "./ToolPageShell";
+import ToolAnimatedPreview from "./ToolAnimatedPreview";
+import ToolScreenshots, { ToolScreenshot } from "./ToolScreenshots";
+import ToolTechStack, { TechStackItem } from "./ToolTechStack";
+
+interface ToolClientPageProps {
+  title: string;
+  githubUrl: string;
+  githubLabel: string;
+  githubText: string;
+  description: ReactNode;
+  preview?: { src: string; poster: string; label: string };
+  imageDir: string;
+  screenshots: ToolScreenshot[];
+  media: "image" | "video";
+  techStack: TechStackItem[];
+}
+
+export default function ToolClientPage({
+  title,
+  githubUrl,
+  githubLabel,
+  githubText,
+  description,
+  preview,
+  imageDir,
+  screenshots,
+  media,
+  techStack,
+}: ToolClientPageProps) {
+  return (
+    <ToolPageShell title={title}>
+      {preview && <ToolAnimatedPreview {...preview} />}
+      <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+        {description}
+        <br />
+        <p>
+          🔗{" "}
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-black dark:hover:text-white"
+            title={githubLabel}
+          >
+            {githubText}
+          </a>
+        </p>
+      </section>
+      <ToolScreenshots
+        screenshots={screenshots}
+        imageDir={imageDir}
+        media={media}
+      />
+      <ToolTechStack items={techStack} />
+    </ToolPageShell>
+  );
+}

--- a/web-buddy/src/app/tools/collectionbuddy/client.tsx
+++ b/web-buddy/src/app/tools/collectionbuddy/client.tsx
@@ -1,9 +1,6 @@
-import ToolPageShell from "../../components/ToolPageShell";
-import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
-import ToolScreenshots, {
-  ToolScreenshot,
-} from "../../components/ToolScreenshots";
-import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
+import ToolClientPage from "../../components/ToolClientPage";
+import { ToolScreenshot } from "../../components/ToolScreenshots";
+import { TechStackItem } from "../../components/ToolTechStack";
 
 const imageDir = "/images/collection-buddy";
 
@@ -50,55 +47,34 @@ const techStack: TechStackItem[] = [
   { name: "Open Street Map", url: "https://www.openstreetmap.org/" },
 ];
 
-function DescriptionSection({ githubUrl }: { githubUrl: string }) {
-  return (
-    <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-      <p>
-        <strong>Collection Buddy</strong> is your elegant solution for cataloging personal collections. Whether you&apos;re organizing stamps, coins, trading cards, or any other collectibles, Collection Buddy provides a beautiful and intuitive interface to keep track of your treasures.
-      </p>
-      <p>
-        Built with modern web technologies like Next.js, React, and Supabase, it offers a seamless experience for adding, viewing, and managing your collection items. The responsive design works perfectly on desktop and mobile devices and can even be installed as a PWA app on your phone.
-      </p>
-      <br />
-      <p>
-        🔗{" "}
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-black dark:hover:text-white"
-          title="collection github"
-        >
-          View the repository on GitHub and start organizing your collection
-        </a>
-      </p>
-    </section>
-  );
-}
-
-interface CollectionBuddyClientProps {
-  title: string;
-  githubUrl: string;
-}
-
 export default function CollectionBuddyClient({
   title,
   githubUrl,
-}: CollectionBuddyClientProps) {
+}: {
+  title: string;
+  githubUrl: string;
+}) {
   return (
-    <ToolPageShell title={title}>
-      <ToolAnimatedPreview
-        src={`${imageDir}/preview.mp4`}
-        poster={`${imageDir}/preview-poster.jpg`}
-        label="Collection Buddy animated preview"
-      />
-      <DescriptionSection githubUrl={githubUrl} />
-      <ToolScreenshots
-        screenshots={screenshots}
-        imageDir={imageDir}
-        media="video"
-      />
-      <ToolTechStack items={techStack} />
-    </ToolPageShell>
+    <ToolClientPage
+      title={title}
+      githubUrl={githubUrl}
+      githubLabel="collection github"
+      githubText="View the repository on GitHub and start organizing your collection"
+      imageDir={imageDir}
+      preview={{
+        src: `${imageDir}/preview.mp4`,
+        poster: `${imageDir}/preview-poster.jpg`,
+        label: "Collection Buddy animated preview",
+      }}
+      screenshots={screenshots}
+      media="video"
+      techStack={techStack}
+      description={
+        <>
+          <p><strong>Collection Buddy</strong> is your elegant solution for cataloging personal collections. Whether you&apos;re organizing stamps, coins, trading cards, or any other collectibles, Collection Buddy provides a beautiful and intuitive interface to keep track of your treasures.</p>
+          <p>Built with modern web technologies like Next.js, React, and Supabase, it offers a seamless experience for adding, viewing, and managing your collection items. The responsive design works perfectly on desktop and mobile devices and can even be installed as a PWA app on your phone.</p>
+        </>
+      }
+    />
   );
 }

--- a/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
+++ b/web-buddy/src/app/tools/procrastinationbuddy/client.tsx
@@ -1,9 +1,6 @@
-import ToolPageShell from "../../components/ToolPageShell";
-import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
-import ToolScreenshots, {
-  ToolScreenshot,
-} from "../../components/ToolScreenshots";
-import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
+import ToolClientPage from "../../components/ToolClientPage";
+import { ToolScreenshot } from "../../components/ToolScreenshots";
+import { TechStackItem } from "../../components/ToolTechStack";
 
 const imageDir = "/images/procrastination-buddy";
 
@@ -46,58 +43,34 @@ const techStack: TechStackItem[] = [
   { name: "uv", url: "https://github.com/astral-sh/uv" },
 ];
 
-function DescriptionSection({ githubUrl }: { githubUrl: string }) {
-  return (
-    <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-      <p>
-        Meet <strong>Procrastination Buddy</strong>, the app that gently
-        encourages you to do absolutely nothing important. Instead of pushing
-        you to focus, it invites you to take a breath, relax, and enjoy the art
-        of doing less.
-      </p>
-      <p>
-        Feel like slowing down for no good reason? You are in the right place.
-      </p>
-      <br />
-      <p>
-        🔗{" "}
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-black dark:hover:text-white"
-          title="procrastination github"
-        >
-          View the repository on GitHub and try it out on your machine
-        </a>
-      </p>
-    </section>
-  );
-}
-
-interface ProcrastinationBuddyClientProps {
-  title: string;
-  githubUrl: string;
-}
-
 export default function ProcrastinationBuddyClient({
   title,
   githubUrl,
-}: ProcrastinationBuddyClientProps) {
+}: {
+  title: string;
+  githubUrl: string;
+}) {
   return (
-    <ToolPageShell title={title}>
-      <ToolAnimatedPreview
-        src={`${imageDir}/buddy-preview.mp4`}
-        poster={`${imageDir}/buddy-preview-poster.jpg`}
-        label="Procrastination Buddy animated preview"
-      />
-      <DescriptionSection githubUrl={githubUrl} />
-      <ToolScreenshots
-        screenshots={screenshots}
-        imageDir={imageDir}
-        media="image"
-      />
-      <ToolTechStack items={techStack} />
-    </ToolPageShell>
+    <ToolClientPage
+      title={title}
+      githubUrl={githubUrl}
+      githubLabel="procrastination github"
+      githubText="View the repository on GitHub and try it out on your machine"
+      imageDir={imageDir}
+      preview={{
+        src: `${imageDir}/buddy-preview.mp4`,
+        poster: `${imageDir}/buddy-preview-poster.jpg`,
+        label: "Procrastination Buddy animated preview",
+      }}
+      screenshots={screenshots}
+      media="image"
+      techStack={techStack}
+      description={
+        <>
+          <p>Meet <strong>Procrastination Buddy</strong>, the app that gently encourages you to do absolutely nothing important. Instead of pushing you to focus, it invites you to take a breath, relax, and enjoy the art of doing less.</p>
+          <p>Feel like slowing down for no good reason? You are in the right place.</p>
+        </>
+      }
+    />
   );
 }

--- a/web-buddy/src/app/tools/ridemergebuddy/client.tsx
+++ b/web-buddy/src/app/tools/ridemergebuddy/client.tsx
@@ -1,8 +1,6 @@
-import ToolPageShell from "../../components/ToolPageShell";
-import ToolScreenshots, {
-  ToolScreenshot,
-} from "../../components/ToolScreenshots";
-import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
+import ToolClientPage from "../../components/ToolClientPage";
+import { ToolScreenshot } from "../../components/ToolScreenshots";
+import { TechStackItem } from "../../components/ToolTechStack";
 
 const imageDir = "/images/ridemerge-buddy";
 
@@ -33,47 +31,26 @@ const techStack: TechStackItem[] = [
   { name: "Gradle", url: "https://gradle.org/" },
 ];
 
-function DescriptionSection({ githubUrl }: { githubUrl: string }) {
-  return (
-    <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-      <p>
-        <strong>RideMergeBuddy</strong> lets you view and merge your Strava activities seamlessly. Select multiple rides or runs, merge them into a new activity, and track everything in one place.
-      </p>
-      <br />
-      <p>
-        🔗{" "}
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-black dark:hover:text-white"
-          title="RideMergeBuddy GitHub"
-        >
-          View the repository on GitHub
-        </a>
-      </p>
-    </section>
-  );
-}
-
-interface RideMergeBuddyClientProps {
-  title: string;
-  githubUrl: string;
-}
-
 export default function RideMergeBuddyClient({
   title,
   githubUrl,
-}: RideMergeBuddyClientProps) {
+}: {
+  title: string;
+  githubUrl: string;
+}) {
   return (
-    <ToolPageShell title={title}>
-      <DescriptionSection githubUrl={githubUrl} />
-      <ToolScreenshots
-        screenshots={screenshots}
-        imageDir={imageDir}
-        media="video"
-      />
-      <ToolTechStack items={techStack} />
-    </ToolPageShell>
+    <ToolClientPage
+      title={title}
+      githubUrl={githubUrl}
+      githubLabel="RideMergeBuddy GitHub"
+      githubText="View the repository on GitHub"
+      imageDir={imageDir}
+      screenshots={screenshots}
+      media="video"
+      techStack={techStack}
+      description={
+        <p><strong>RideMergeBuddy</strong> lets you view and merge your Strava activities seamlessly. Select multiple rides or runs, merge them into a new activity, and track everything in one place.</p>
+      }
+    />
   );
 }

--- a/web-buddy/src/app/tools/thrashbuddy/client.tsx
+++ b/web-buddy/src/app/tools/thrashbuddy/client.tsx
@@ -1,9 +1,6 @@
-import ToolPageShell from "../../components/ToolPageShell";
-import ToolAnimatedPreview from "../../components/ToolAnimatedPreview";
-import ToolScreenshots, {
-  ToolScreenshot,
-} from "../../components/ToolScreenshots";
-import ToolTechStack, { TechStackItem } from "../../components/ToolTechStack";
+import ToolClientPage from "../../components/ToolClientPage";
+import { ToolScreenshot } from "../../components/ToolScreenshots";
+import { TechStackItem } from "../../components/ToolTechStack";
 
 const imageDir = "/images/thrash-buddy";
 
@@ -46,55 +43,34 @@ const techStack: TechStackItem[] = [
   { name: "Minikube", url: "https://minikube.sigs.k8s.io/" },
 ];
 
-function DescriptionSection({ githubUrl }: { githubUrl: string }) {
-  return (
-    <section className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-      <p>
-        <strong>Thrash Buddy</strong> is your go-to solution for cloud-native performance testing. Whether you&apos;re preparing for a product launch or scaling your infrastructure, Thrash Buddy helps you simulate real-world load with confidence.
-      </p>
-      <p>
-        Built on top of powerful tools like k6, Prometheus, and Grafana, it enables distributed load testing across Kubernetes clusters, giving you deep insights into how your app performs under pressure.
-      </p>
-      <br />
-      <p>
-        🔗{" "}
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-black dark:hover:text-white"
-          title="thrash github"
-        >
-          View the repository on GitHub and try it out on your infrastructure
-        </a>
-      </p>
-    </section>
-  );
-}
-
-interface ThrashBuddyClientProps {
-  title: string;
-  githubUrl: string;
-}
-
 export default function ThrashBuddyClient({
   title,
   githubUrl,
-}: ThrashBuddyClientProps) {
+}: {
+  title: string;
+  githubUrl: string;
+}) {
   return (
-    <ToolPageShell title={title}>
-      <ToolAnimatedPreview
-        src="/images/thrash-buddy/preview.mp4"
-        poster="/images/thrash-buddy/preview-poster.jpg"
-        label="Thrash Buddy animated preview"
-      />
-      <DescriptionSection githubUrl={githubUrl} />
-      <ToolScreenshots
-        screenshots={screenshots}
-        imageDir={imageDir}
-        media="image"
-      />
-      <ToolTechStack items={techStack} />
-    </ToolPageShell>
+    <ToolClientPage
+      title={title}
+      githubUrl={githubUrl}
+      githubLabel="thrash github"
+      githubText="View the repository on GitHub and try it out on your infrastructure"
+      imageDir={imageDir}
+      preview={{
+        src: "/images/thrash-buddy/preview.mp4",
+        poster: "/images/thrash-buddy/preview-poster.jpg",
+        label: "Thrash Buddy animated preview",
+      }}
+      screenshots={screenshots}
+      media="image"
+      techStack={techStack}
+      description={
+        <>
+          <p><strong>Thrash Buddy</strong> is your go-to solution for cloud-native performance testing. Whether you&apos;re preparing for a product launch or scaling your infrastructure, Thrash Buddy helps you simulate real-world load with confidence.</p>
+          <p>Built on top of powerful tools like k6, Prometheus, and Grafana, it enables distributed load testing across Kubernetes clusters, giving you deep insights into how your app performs under pressure.</p>
+        </>
+      }
+    />
   );
 }


### PR DESCRIPTION
## Summary
Part of #524. Four of the five tool client components (Procrastination, Thrash, Collection, RideMerge Buddy) repeated an identical shape: a local `DescriptionSection` wrapper, a one-off props interface, and the same `ToolPageShell` → `ToolAnimatedPreview` → description → `ToolScreenshots` → `ToolTechStack` composition, differing only in data.

## Changes
- New `components/ToolClientPage.tsx` holding the shared composition + the repeated GitHub-link footer markup
- The four tool client files now only declare their own data (screenshots, tech stack, description copy) and pass it in
- `gamegallerybuddy/client.tsx` is untouched — it has a genuinely different layout (two images, extra paragraph) and doesn't fit the shared shape without forcing it

Net: -39 lines across the affected files, no behavior change.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `CI=true npx playwright test` (157/157 passing)

Part of #524 — leaving that issue open, this is a first pass; the rest of `web-buddy/src` (already fairly lean — comments are already "why not what" throughout) didn't turn up further low-risk wins in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)