### PR TITLE
fix: sticky manifesto reveal, JS ease-to-section snap, visible intro emojis

### DIFF
--- a/web-buddy/src/app/components/EmojiBackground.tsx
+++ b/web-buddy/src/app/components/EmojiBackground.tsx
@@ -139,7 +139,7 @@ export default function EmojiGridCanvas() {
   return (
     <canvas
       ref={canvasRef}
-      className="fixed inset-0 z-0 pointer-events-none opacity-10 grayscale select-none"
+      className="fixed inset-0 z-0 pointer-events-none opacity-[0.16] grayscale select-none"
     />
   );
 }

--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -27,15 +27,40 @@ const ideas = [
 
 const sectionCount = ideas.length + 1; // + call-to-action
 
-// One shared observer drives both the reveal-on-enter animation and the
-// right-side dot rail — every section already needs the same "is this one
-// roughly centered" answer, so there's no need for a separate observer per
-// section (or a second one just for the dots). Sections receive a `register`
-// callback rather than the ref array itself, so they never mutate a value
-// owned by the parent hook directly.
-function useActiveSections() {
+// Eases the section you *stopped* in to fill the viewport, but only after
+// scrolling settles — it never intercepts an active scroll (so, unlike the
+// old CSS scroll-snap, there's no scroll-jacking or keyboard trap, #413).
+// The intro/terminal section isn't registered here, so stopping to read it
+// is never yanked into the manifesto.
+function snapToStoppedSection(refs: (HTMLElement | null)[]) {
+  const vh = window.innerHeight;
+  const viewportCenter = window.scrollY + vh / 2;
+  for (const el of refs) {
+    if (!el) continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.height > vh + 4) continue; // taller than the viewport: can't center
+    const top = rect.top + window.scrollY;
+    if (viewportCenter < top || viewportCenter >= top + rect.height) continue;
+    const target = top + rect.height / 2 - vh / 2;
+    if (Math.abs(target - window.scrollY) > 3) {
+      window.scrollTo({ top: target, behavior: "smooth" });
+    }
+    return;
+  }
+}
+
+// One shared observer drives both the reveal animation and the dot rail —
+// `active` tracks whichever section is currently centered (for the dots),
+// while `revealed` latches true the first time a section appears and never
+// clears, so already-seen content stays revealed on scroll-away. Sections
+// receive a `register` callback rather than the ref array itself, so they
+// never mutate a value owned by the parent hook directly.
+function useManifesto() {
   const refs = useRef<(HTMLElement | null)[]>([]);
   const [active, setActive] = useState<boolean[]>(() =>
+    Array(sectionCount).fill(false)
+  );
+  const [revealed, setRevealed] = useState<boolean[]>(() =>
     Array(sectionCount).fill(false)
   );
 
@@ -50,6 +75,18 @@ function useActiveSections() {
           }
           return next;
         });
+        setRevealed((prev) => {
+          let changed = false;
+          const next = [...prev];
+          for (const entry of entries) {
+            const i = refs.current.indexOf(entry.target as HTMLElement);
+            if (i !== -1 && entry.isIntersecting && !next[i]) {
+              next[i] = true;
+              changed = true;
+            }
+          }
+          return changed ? next : prev;
+        });
       },
       { threshold: 0.55 }
     );
@@ -57,27 +94,41 @@ function useActiveSections() {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const onScroll = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => snapToStoppedSection(refs.current), 120);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      clearTimeout(timer);
+    };
+  }, []);
+
   const register = (index: number) => (el: HTMLElement | null) => {
     refs.current[index] = el;
   };
 
-  return { register, active };
+  return { register, active, revealed };
 }
 
 function ManifestoSection({
   register,
-  active,
+  revealed,
   emoji,
   title,
   body,
 }: (typeof ideas)[number] & {
   register: (el: HTMLElement | null) => void;
-  active: boolean;
+  revealed: boolean;
 }) {
   return (
     <section
       ref={register}
-      className={`manifesto-section min-h-screen snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${active ? "in-view" : ""}`}
+      className={`manifesto-section min-h-screen snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-emoji text-6xl mb-6">{emoji}</div>
       <h2 className="text-2xl sm:text-3xl font-bold mb-4">{title}</h2>
@@ -90,15 +141,15 @@ function ManifestoSection({
 
 function CallToActionSection({
   register,
-  active,
+  revealed,
 }: {
   register: (el: HTMLElement | null) => void;
-  active: boolean;
+  revealed: boolean;
 }) {
   return (
     <section
       ref={register}
-      className={`manifesto-section h-screen snap-center flex flex-col justify-center items-center text-center p-10 ${active ? "in-view" : ""}`}
+      className={`manifesto-section h-screen snap-center flex flex-col justify-center items-center text-center p-10 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-cta-text text-xl sm:text-2xl mb-6">
         Explore the tools. Adopt a Buddy.
@@ -114,9 +165,9 @@ function CallToActionSection({
   );
 }
 
-// Purely a visual scroll-position affordance — the section headings
-// already convey where you are, so this stays out of the accessibility
-// tree rather than adding redundant, constantly-changing announcements.
+// Purely a visual scroll-position affordance — the section headings already
+// convey where you are, so this stays out of the accessibility tree rather
+// than adding redundant, constantly-changing announcements.
 function ScrollDots({ active }: { active: boolean[] }) {
   const activeIndex = active.lastIndexOf(true);
   return (
@@ -132,7 +183,7 @@ function ScrollDots({ active }: { active: boolean[] }) {
 }
 
 export default function ManifestoScroll() {
-  const { register, active } = useActiveSections();
+  const { register, active, revealed } = useManifesto();
 
   return (
     <div className="manifesto-gradient">
@@ -140,13 +191,13 @@ export default function ManifestoScroll() {
         <ManifestoSection
           key={idea.title}
           register={register(i)}
-          active={active[i]}
+          revealed={revealed[i]}
           {...idea}
         />
       ))}
       <CallToActionSection
         register={register(ideas.length)}
-        active={active[ideas.length]}
+        revealed={revealed[ideas.length]}
       />
       <ScrollDots active={active} />
     </div>

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -60,43 +60,6 @@ html {
   scrollbar-gutter: stable;
 }
 
-/* scroll-snap-type only has an effect on the element that actually scrolls.
-   <main> never establishes its own scroll container here (no overflow/
-   height of its own — Header is fixed and out of flow, so the *document*
-   scrolls), so the property has to live on the real scrolling element
-   (html, via document.scrollingElement) instead. :has() scopes it to the
-   homepage only, keyed off the marker attribute on its <main>, without
-   needing every other route to know or care about this.
-
-   mandatory (not proximity): proximity leaves snapping entirely up to the
-   browser's own heuristics, and in Chromium that heuristic turns out to
-   almost never fire on ordinary wheel/trackpad input — verified by
-   landing a scroll 1px short of a section's snap point and finding it
-   never gets pulled the rest of the way, which is the "not snappy"
-   complaint. mandatory guarantees the scroll always rests on a snap point.
-   scroll-snap-stop is left at its default ("normal", not "always"), so a
-   fast fling can still sail past several sections in one gesture — only
-   the *resting* position is forced onto a snap point.
-
-   #413 previously reported mandatory as scroll-jacking + a keyboard trap,
-   but that was a different setup: main was itself a focus-untouchable
-   `h-screen overflow-y-scroll` div back then, so keyboard scrolling (which
-   targets the focused/default scrollable area) never reached it at all,
-   and every wheel tick was captured by that inner scroller one section at
-   a time. #413's own fix removed that inner scroller so the *document*
-   scrolls natively — which is exactly what's back in use here. Native
-   document scrolling honors PageDown/arrow/Home/End the same way it
-   honors wheel input, so there's no separate unfocusable container left
-   to trap keyboard users behind. */
-html:has(main[data-manifesto-scroll]) {
-  scroll-snap-type: y mandatory;
-}
-@media (prefers-reduced-motion: reduce) {
-  html:has(main[data-manifesto-scroll]) {
-    scroll-snap-type: none;
-  }
-}
-
 @keyframes fade-in-up {
   from {
     opacity: 0;
@@ -124,14 +87,31 @@ html:has(main[data-manifesto-scroll]) {
 
 /* Homepage manifesto scroll effects: one continuous gradient painted
    behind all manifesto sections (replacing hard per-section color cuts),
-   plus a progressive reveal driven by useInView (JS/IntersectionObserver
-   + CSS transition) rather than animation-timeline — the latter is newer
-   CSS that can silently no-op in some browsers, which a purely decorative
-   reveal effect shouldn't risk. */
+   plus a progressive reveal driven by an IntersectionObserver + CSS
+   transition rather than animation-timeline — the latter is newer CSS that
+   can silently no-op in some browsers, which a purely decorative reveal
+   effect shouldn't risk.
+
+   The gradient lives on a ::before rather than the element's own
+   background so it can be masked to fade in from transparent over the
+   first ~60vh: that fade lets the fixed EmojiBackground canvas (sitting
+   behind the whole page) stay visible through the intro and into the first
+   bit of scroll, instead of being hard-covered the instant the manifesto
+   starts. Masking the pseudo-element leaves the section content itself
+   fully opaque/readable. */
 .manifesto-gradient {
+  position: relative;
+}
+.manifesto-gradient::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   background-image: var(--manifesto-gradient);
   background-size: 100% 100%;
   background-repeat: no-repeat;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 60vh);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 60vh);
 }
 
 .manifesto-section h2,

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -32,11 +32,8 @@ export default function HomePage() {
     <>
       <JsonLd id="jsonld-home" data={jsonLd} />
       <Header />
-      <main
-        data-manifesto-scroll
-        className="text-black dark:text-white overflow-x-hidden"
-      >
-        <section className="min-h-screen snap-center">
+      <main className="text-black dark:text-white overflow-x-hidden">
+        <section className="min-h-screen">
           <CirclesBackground variant="home" />
           <TerminalIntro />
         </section>

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -8,8 +8,10 @@ test.describe("homepage manifesto scroll effects", () => {
 
     const gradientWrap = page.locator(".manifesto-gradient");
     await expect(gradientWrap).toBeAttached();
+    // The gradient lives on ::before (so it can be masked to fade in over
+    // the intro without masking the section content).
     const backgroundImage = await gradientWrap.evaluate(
-      (el) => getComputedStyle(el).backgroundImage
+      (el) => getComputedStyle(el, "::before").backgroundImage
     );
     expect(backgroundImage).toContain("gradient");
   });
@@ -36,6 +38,24 @@ test.describe("homepage manifesto scroll effects", () => {
     const heading = page.getByRole("heading", {
       name: "Software can be useful and weird",
     });
+    await expect(heading).toHaveCSS("opacity", "1");
+  });
+
+  test("a revealed section stays revealed after it scrolls back out of view", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const heading = page.getByRole("heading", {
+      name: "Software can be useful and weird",
+    });
+    await heading.scrollIntoViewIfNeeded();
+    await expect(heading).toHaveCSS("opacity", "1", { timeout: 2000 });
+
+    // Scroll far past it; its reveal must latch, so it stays opaque even
+    // while off-screen (opacity is still computable when scrolled away).
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(400);
     await expect(heading).toHaveCSS("opacity", "1");
   });
 

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -1,59 +1,55 @@
 import { test, expect } from "@playwright/test";
 
-// scroll-snap-type only affects the element that actually scrolls. <main>
-// has no overflow/height of its own (the document scrolls, per #413's
-// fix), so it must live on <html> instead — asserting it on <main> would
-// pass without the snap ever functioning, which is exactly how this
-// regressed silently before. See globals.css for the full mandatory vs.
-// proximity rationale, and homepage.spec.ts's "reachable via keyboard
-// scrolling" test for the #413 keyboard coverage this must not break.
-test.describe("homepage scroll snap", () => {
-  test("the real scrolling element (html) has mandatory snap, with matching snap-center targets", async ({
+// The homepage eases whichever manifesto section you *stopped* in to fill
+// the viewport, once scrolling settles (JS, in ManifestoScroll). Unlike CSS
+// scroll-snap this is deterministic, so it can be asserted directly. See
+// homepage.spec.ts for the keyboard-reachability coverage this must keep.
+
+// scrollY that centers the given manifesto section in the viewport.
+async function centerOf(page: import("@playwright/test").Page, index: number) {
+  return page.evaluate((i) => {
+    const el = document.querySelectorAll(".manifesto-section")[i] as HTMLElement;
+    const top = el.getBoundingClientRect().top + window.scrollY;
+    return Math.round(top + el.offsetHeight / 2 - window.innerHeight / 2);
+  }, index);
+}
+
+test.describe("homepage scroll snap (ease-to-section on settle)", () => {
+  test("eases a partially-scrolled section to centered once scrolling stops", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const target = await centerOf(page, 1);
+
+    // Land inside section 1 but well off-center, then let it settle.
+    await page.evaluate((y) => window.scrollTo(0, y), target - 120);
+    await page.waitForTimeout(700);
+
+    const settled = await page.evaluate(() => window.scrollY);
+    expect(Math.abs(settled - target)).toBeLessThan(6);
+  });
+
+  test("does not yank you out of the intro/terminal section", async ({
     page,
   }) => {
     await page.goto("/");
 
-    const scrollingElement = await page.evaluate(
-      () => document.scrollingElement === document.documentElement
-    );
-    expect(scrollingElement).toBe(true);
+    await page.evaluate(() => window.scrollTo(0, 90));
+    await page.waitForTimeout(700);
 
-    const html = page.locator("html");
-    await expect(html).toHaveCSS("scroll-snap-type", "y mandatory");
-
-    // <main> itself must NOT carry a (dead) scroll-snap-type of its own —
-    // that's the exact bug this fixes.
-    const main = page.locator("main");
-    await expect(main).toHaveCSS("scroll-snap-type", "none");
-
-    const snapTargets = page.locator(
-      "main > section, main > div > section"
-    );
-    const count = await snapTargets.count();
-    expect(count).toBeGreaterThanOrEqual(5);
-
-    for (let i = 0; i < count; i++) {
-      await expect(snapTargets.nth(i)).toHaveCSS(
-        "scroll-snap-align",
-        "center"
-      );
-    }
+    const settled = await page.evaluate(() => window.scrollY);
+    expect(settled).toBe(90);
   });
 
-  test("snap is disabled under prefers-reduced-motion", async ({ page }) => {
+  test("does not snap under prefers-reduced-motion", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/");
+    const target = await centerOf(page, 1);
 
-    const html = page.locator("html");
-    await expect(html).toHaveCSS("scroll-snap-type", "none");
-  });
+    await page.evaluate((y) => window.scrollTo(0, y), target - 120);
+    await page.waitForTimeout(700);
 
-  test("snap is scoped to the homepage, not applied site-wide", async ({
-    page,
-  }) => {
-    await page.goto("/about");
-
-    const html = page.locator("html");
-    await expect(html).toHaveCSS("scroll-snap-type", "none");
+    const settled = await page.evaluate(() => window.scrollY);
+    expect(settled).toBe(target - 120);
   });
 });


### PR DESCRIPTION
## Summary
Closes #531 — three follow-up refinements to the homepage manifesto scroll experience.

### 1. Progressive reveal now latches (stops un-revealing)
The shared `IntersectionObserver` now tracks two things: `active` (currently-centered section, still toggles for the dot rail) and `revealed` (set true the first time a section appears, **never cleared**). Sections key their reveal on `revealed`, so already-seen text stays visible on scroll-away.

### 2. CSS scroll-snap → JS ease-to-section on settle
CSS scroll-snap's settle behavior proved unreliable across browsers/trackpads (three "not snappy" reports, even after #527 moved the property onto the real scrolling element and switched to `mandatory`). Replaced with a small JS handler: ~120ms after scrolling **stops**, it eases whichever section your viewport center is inside to centered. It never intercepts an active scroll (no scroll-jacking / keyboard trap, #413), and the intro/terminal section isn't a snap target so reading it is never yanked away. Bonus: it's deterministic, so the rewritten `scroll-snap.spec.ts` asserts the **actual settle position** rather than just a computed CSS value.

### 3. Floating emojis visible around the intro again
The `.manifesto-gradient` moved from the element's own background onto a `::before`, masked to fade in from transparent over the first `60vh`. So the fixed `EmojiBackground` canvas shows through the intro and into the first bit of scroll, instead of being hard-covered the instant the manifesto starts (masking the pseudo-element leaves the section text fully opaque). Also nudged the canvas opacity `0.10 → 0.16` so the emojis actually read.

> Note: #3 is a first cut on a fuzzy/visual ask — happy to push the transparent zone taller, extend it into the terminal section, or dial the opacity if it's not quite the feel you meant once you see it live.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **160/160**, including new/rewritten coverage:
  - sticky reveal persists while the section is scrolled off-screen
  - ease-to-section centers a partially-scrolled section once scrolling settles
  - the intro/terminal section is never yanked into the manifesto
  - no snap under `prefers-reduced-motion`
  - existing keyboard-reachability coverage still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)