### PR TITLE
feat: one-page-per-gesture manifesto snap + faster gradient fade

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -27,25 +27,69 @@ const ideas = [
 
 const sectionCount = ideas.length + 1; // + call-to-action
 
-// Eases the section you *stopped* in to fill the viewport, but only after
-// scrolling settles — it never intercepts an active scroll (so, unlike the
-// old CSS scroll-snap, there's no scroll-jacking or keyboard trap, #413).
-// The intro/terminal section isn't registered here, so stopping to read it
-// is never yanked into the manifesto.
-function snapToStoppedSection(refs: (HTMLElement | null)[]) {
+// Distance (as a fraction of the viewport) a scroll must cover away from
+// the current page before it commits to the adjacent one. Small enough that
+// one ordinary scroll gesture flips a whole page — the "page scroll" feel —
+// without a tiny nudge accidentally triggering it.
+const PAGE_COMMIT = 0.2;
+
+// Snaps one page per gesture, but only after scrolling settles — it never
+// intercepts an active scroll (so, unlike the old CSS scroll-snap, there's
+// no scroll-jacking or keyboard trap, #413). Anchored on the page you last
+// landed on: a modest scroll in either direction commits to the neighbour,
+// a big fling lands on the nearest. The intro/terminal section isn't a page
+// here, so stopping to read it is never yanked into the manifesto.
+function pageSnap(refs: (HTMLElement | null)[], pageRef: { current: number }) {
   const vh = window.innerHeight;
-  const viewportCenter = window.scrollY + vh / 2;
-  for (const el of refs) {
-    if (!el) continue;
+  const y = window.scrollY;
+
+  // Scroll position at which each section is centered in the viewport.
+  const tops = refs.map((el) => {
+    if (!el) return null;
     const rect = el.getBoundingClientRect();
-    if (rect.height > vh + 4) continue; // taller than the viewport: can't center
-    const top = rect.top + window.scrollY;
-    if (viewportCenter < top || viewportCenter >= top + rect.height) continue;
-    const target = top + rect.height / 2 - vh / 2;
-    if (Math.abs(target - window.scrollY) > 3) {
-      window.scrollTo({ top: target, behavior: "smooth" });
-    }
+    if (rect.height > vh * 1.5) return null; // too tall to page cleanly
+    return rect.top + y + rect.height / 2 - vh / 2;
+  });
+
+  const firstTop = tops.find((t): t is number => t != null);
+  if (firstTop === undefined) return;
+
+  // Still up in the intro/terminal: leave scrolling completely free.
+  if (y < firstTop - vh * 0.5) {
+    pageRef.current = -1;
     return;
+  }
+
+  let nearest = -1;
+  let nearestDist = Infinity;
+  tops.forEach((t, i) => {
+    if (t == null) return;
+    const dist = Math.abs(t - y);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = i;
+    }
+  });
+
+  let target = nearest;
+  const cur = pageRef.current;
+  const curTop = cur >= 0 ? tops[cur] : null;
+  if (curTop != null && Math.abs(y - curTop) <= vh * 1.2) {
+    const delta = y - curTop;
+    if (delta > vh * PAGE_COMMIT && cur + 1 < tops.length && tops[cur + 1] != null) {
+      target = cur + 1;
+    } else if (delta < -vh * PAGE_COMMIT && cur - 1 >= 0 && tops[cur - 1] != null) {
+      target = cur - 1;
+    } else {
+      target = cur;
+    }
+  }
+  if (target < 0) return;
+
+  pageRef.current = target;
+  const ty = tops[target];
+  if (ty != null && Math.abs(ty - y) > 3) {
+    window.scrollTo({ top: ty, behavior: "smooth" });
   }
 }
 
@@ -96,10 +140,11 @@ function useManifesto() {
 
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const pageRef = { current: -1 };
     let timer: ReturnType<typeof setTimeout>;
     const onScroll = () => {
       clearTimeout(timer);
-      timer = setTimeout(() => snapToStoppedSection(refs.current), 120);
+      timer = setTimeout(() => pageSnap(refs.current, pageRef), 120);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => {

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -94,7 +94,7 @@ html {
 
    The gradient lives on a ::before rather than the element's own
    background so it can be masked to fade in from transparent over the
-   first ~60vh: that fade lets the fixed EmojiBackground canvas (sitting
+   first ~30vh: that fade lets the fixed EmojiBackground canvas (sitting
    behind the whole page) stay visible through the intro and into the first
    bit of scroll, instead of being hard-covered the instant the manifesto
    starts. Masking the pseudo-element leaves the section content itself
@@ -110,8 +110,8 @@ html {
   background-image: var(--manifesto-gradient);
   background-size: 100% 100%;
   background-repeat: no-repeat;
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 60vh);
-  mask-image: linear-gradient(to bottom, transparent 0, #000 60vh);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 30vh);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 30vh);
 }
 
 .manifesto-section h2,

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -29,6 +29,26 @@ test.describe("homepage scroll snap (ease-to-section on settle)", () => {
     expect(Math.abs(settled - target)).toBeLessThan(6);
   });
 
+  test("a modest scroll past a page commits to the next section (page-scroll feel)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const c1 = await centerOf(page, 1);
+    const c2 = await centerOf(page, 2);
+
+    // Land centered on section 1 first so it becomes the anchored page.
+    await page.evaluate((y) => window.scrollTo(0, y), c1);
+    await page.waitForTimeout(700);
+
+    // A ~30% viewport nudge downward should page all the way to section 2,
+    // not settle back on section 1.
+    await page.evaluate(() => window.scrollBy(0, window.innerHeight * 0.3));
+    await page.waitForTimeout(700);
+
+    const settled = await page.evaluate(() => window.scrollY);
+    expect(Math.abs(settled - c2)).toBeLessThan(6);
+  });
+
   test("does not yank you out of the intro/terminal section", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
Closes #534, plus a small tuning of #531's emoji-reveal gradient.

### Page-scroll feel (#534)
The ease-to-section snap re-centered whichever section your viewport center was mostly in, so a partial scroll toward the next one pulled you back — sticky rather than page-like. It now **anchors on the page you last landed on** and, on settle, a modest scroll (~20% of the viewport, `PAGE_COMMIT`) in either direction commits to the **adjacent** section — one page per gesture. A large fling still lands on the nearest section.

Unchanged safety properties from #531:
- Settle-only — never intercepts an active scroll (no scroll-jacking / keyboard trap, #413)
- The intro/terminal section isn't a page (reading it is never yanked away)
- Disabled under `prefers-reduced-motion`

### Faster gradient fade (tuning #531)
The emoji-reveal gradient now fades transparent → opaque over **30vh** instead of 60vh, so the transition changes faster as requested.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **161/161**, including a new test asserting a ~30% nudge past a centered page commits to the next section (and the existing "doesn't yank from intro" / reduced-motion / sticky-reveal coverage still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)