### PR TITLE
fix: replace document-level manifesto snap with a real nested scroll-snap slider

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -27,72 +27,6 @@ const ideas = [
 
 const sectionCount = ideas.length + 1; // + call-to-action
 
-// Distance (as a fraction of the viewport) a scroll must cover away from
-// the current page before it commits to the adjacent one. Small enough that
-// one ordinary scroll gesture flips a whole page — the "page scroll" feel —
-// without a tiny nudge accidentally triggering it.
-const PAGE_COMMIT = 0.2;
-
-// Snaps one page per gesture, but only after scrolling settles — it never
-// intercepts an active scroll (so, unlike the old CSS scroll-snap, there's
-// no scroll-jacking or keyboard trap, #413). Anchored on the page you last
-// landed on: a modest scroll in either direction commits to the neighbour,
-// a big fling lands on the nearest. The intro/terminal section isn't a page
-// here, so stopping to read it is never yanked into the manifesto.
-function pageSnap(refs: (HTMLElement | null)[], pageRef: { current: number }) {
-  const vh = window.innerHeight;
-  const y = window.scrollY;
-
-  // Scroll position at which each section is centered in the viewport.
-  const tops = refs.map((el) => {
-    if (!el) return null;
-    const rect = el.getBoundingClientRect();
-    if (rect.height > vh * 1.5) return null; // too tall to page cleanly
-    return rect.top + y + rect.height / 2 - vh / 2;
-  });
-
-  const firstTop = tops.find((t): t is number => t != null);
-  if (firstTop === undefined) return;
-
-  // Still up in the intro/terminal: leave scrolling completely free.
-  if (y < firstTop - vh * 0.5) {
-    pageRef.current = -1;
-    return;
-  }
-
-  let nearest = -1;
-  let nearestDist = Infinity;
-  tops.forEach((t, i) => {
-    if (t == null) return;
-    const dist = Math.abs(t - y);
-    if (dist < nearestDist) {
-      nearestDist = dist;
-      nearest = i;
-    }
-  });
-
-  let target = nearest;
-  const cur = pageRef.current;
-  const curTop = cur >= 0 ? tops[cur] : null;
-  if (curTop != null && Math.abs(y - curTop) <= vh * 1.2) {
-    const delta = y - curTop;
-    if (delta > vh * PAGE_COMMIT && cur + 1 < tops.length && tops[cur + 1] != null) {
-      target = cur + 1;
-    } else if (delta < -vh * PAGE_COMMIT && cur - 1 >= 0 && tops[cur - 1] != null) {
-      target = cur - 1;
-    } else {
-      target = cur;
-    }
-  }
-  if (target < 0) return;
-
-  pageRef.current = target;
-  const ty = tops[target];
-  if (ty != null && Math.abs(ty - y) > 3) {
-    window.scrollTo({ top: ty, behavior: "smooth" });
-  }
-}
-
 // One shared observer drives both the reveal animation and the dot rail —
 // `active` tracks whichever section is currently centered (for the dots),
 // while `revealed` latches true the first time a section appears and never
@@ -136,21 +70,6 @@ function useManifesto() {
     );
     refs.current.forEach((el) => el && observer.observe(el));
     return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const pageRef = { current: -1 };
-    let timer: ReturnType<typeof setTimeout>;
-    const onScroll = () => {
-      clearTimeout(timer);
-      timer = setTimeout(() => pageSnap(refs.current, pageRef), 120);
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      clearTimeout(timer);
-    };
   }, []);
 
   const register = (index: number) => (el: HTMLElement | null) => {
@@ -231,20 +150,33 @@ export default function ManifestoScroll() {
   const { register, active, revealed } = useManifesto();
 
   return (
-    <div className="manifesto-gradient">
-      {ideas.map((idea, i) => (
-        <ManifestoSection
-          key={idea.title}
-          register={register(i)}
-          revealed={revealed[i]}
-          {...idea}
-        />
-      ))}
-      <CallToActionSection
-        register={register(ideas.length)}
-        revealed={revealed[ideas.length]}
-      />
+    <>
+      {/* Its own overflow-y scroll container (not the document) is what
+          makes native scroll-snap actually reliable — see globals.css for
+          why. tabIndex + aria-label keep it keyboard-reachable, since a
+          nested scroll container isn't otherwise focusable and none of the
+          idea sections contain a focusable element of their own (#413). */}
+      <div
+        className="manifesto-slider"
+        tabIndex={0}
+        aria-label="Manifesto: what nobuddy.org is about"
+      >
+        <div className="manifesto-gradient">
+          {ideas.map((idea, i) => (
+            <ManifestoSection
+              key={idea.title}
+              register={register(i)}
+              revealed={revealed[i]}
+              {...idea}
+            />
+          ))}
+          <CallToActionSection
+            register={register(ideas.length)}
+            revealed={revealed[ideas.length]}
+          />
+        </div>
+      </div>
       <ScrollDots active={active} />
-    </div>
+    </>
   );
 }

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -60,6 +60,36 @@ html {
   scrollbar-gutter: stable;
 }
 
+/* The manifesto's own scroll container, not the document. scroll-snap only
+   settles reliably when it's set on the actual overflow:auto/scroll box —
+   snapping the whole document (even correctly targeting the real
+   document.scrollingElement) proved flaky across browsers/trackpads in
+   practice. A plain nested overflow-y box needs no sticky positioning or
+   JS to "take over" scrolling: the browser's own scroll-chaining already
+   sends wheel/touch input to whichever scrollable element is under the
+   pointer first, only falling through to the outer page once this
+   container's own scroll is exhausted. The intro/terminal section lives
+   outside this element entirely, so reading it is never interrupted.
+
+   A nested scroll container isn't independently reachable by keyboard
+   scrolling unless it's focusable — see the tabIndex + aria-label on
+   ManifestoScroll's wrapper div, matching #413's own suggested fix for
+   this exact pattern. */
+.manifesto-slider {
+  height: 100dvh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scrollbar-width: none;
+}
+.manifesto-slider::-webkit-scrollbar {
+  display: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .manifesto-slider {
+    scroll-snap-type: none;
+  }
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;

--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -42,6 +42,10 @@ test.describe("homepage hero and manifesto content", () => {
     const cta = page.getByRole("link", { name: "Launch /tools →" });
     await expect(cta).not.toBeInViewport();
 
+    // The manifesto is its own scroll container (see scroll-snap.spec.ts),
+    // so keyboard scrolling reaches it the same way any keyboard user
+    // would: Tab until it's focused, then scroll it directly.
+    await page.locator(".manifesto-slider").focus();
     await page.keyboard.press("End");
     await expect(cta).toBeInViewport({ timeout: 3000 });
   });

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -1,75 +1,67 @@
 import { test, expect } from "@playwright/test";
 
-// The homepage eases whichever manifesto section you *stopped* in to fill
-// the viewport, once scrolling settles (JS, in ManifestoScroll). Unlike CSS
-// scroll-snap this is deterministic, so it can be asserted directly. See
-// homepage.spec.ts for the keyboard-reachability coverage this must keep.
-
-// scrollY that centers the given manifesto section in the viewport.
-async function centerOf(page: import("@playwright/test").Page, index: number) {
-  return page.evaluate((i) => {
-    const el = document.querySelectorAll(".manifesto-section")[i] as HTMLElement;
-    const top = el.getBoundingClientRect().top + window.scrollY;
-    return Math.round(top + el.offsetHeight / 2 - window.innerHeight / 2);
-  }, index);
-}
-
-test.describe("homepage scroll snap (ease-to-section on settle)", () => {
-  test("eases a partially-scrolled section to centered once scrolling stops", async ({
-    page,
-  }) => {
-    await page.goto("/");
-    const target = await centerOf(page, 1);
-
-    // Land inside section 1 but well off-center, then let it settle.
-    await page.evaluate((y) => window.scrollTo(0, y), target - 120);
-    await page.waitForTimeout(700);
-
-    const settled = await page.evaluate(() => window.scrollY);
-    expect(Math.abs(settled - target)).toBeLessThan(6);
-  });
-
-  test("a modest scroll past a page commits to the next section (page-scroll feel)", async ({
-    page,
-  }) => {
-    await page.goto("/");
-    const c1 = await centerOf(page, 1);
-    const c2 = await centerOf(page, 2);
-
-    // Land centered on section 1 first so it becomes the anchored page.
-    await page.evaluate((y) => window.scrollTo(0, y), c1);
-    await page.waitForTimeout(700);
-
-    // A ~30% viewport nudge downward should page all the way to section 2,
-    // not settle back on section 1.
-    await page.evaluate(() => window.scrollBy(0, window.innerHeight * 0.3));
-    await page.waitForTimeout(700);
-
-    const settled = await page.evaluate(() => window.scrollY);
-    expect(Math.abs(settled - c2)).toBeLessThan(6);
-  });
-
-  test("does not yank you out of the intro/terminal section", async ({
+// The manifesto sections live in their own overflow-y:auto scroll
+// container (.manifesto-slider) with native CSS scroll-snap — see
+// globals.css for why this (not a document-level snap, not a JS-driven
+// ease) is the version that's actually reliable. Real wheel/trackpad
+// input isn't something Playwright's synthetic events can reliably
+// exercise in headless Chromium (a known CDP limitation, not a sign the
+// CSS is wrong — see the PR description), so this asserts the CSS is
+// correctly declared plus the keyboard-driven settle, which *is*
+// deterministic and directly observable.
+test.describe("homepage manifesto scroll snap", () => {
+  test("the manifesto has its own snap container, separate from the intro", async ({
     page,
   }) => {
     await page.goto("/");
 
-    await page.evaluate(() => window.scrollTo(0, 90));
-    await page.waitForTimeout(700);
+    const slider = page.locator(".manifesto-slider");
+    await expect(slider).toHaveCSS("overflow-y", "auto");
+    await expect(slider).toHaveCSS("scroll-snap-type", "y mandatory");
 
-    const settled = await page.evaluate(() => window.scrollY);
-    expect(settled).toBe(90);
+    const sections = page.locator(".manifesto-slider .manifesto-section");
+    const count = await sections.count();
+    expect(count).toBeGreaterThanOrEqual(5);
+    for (let i = 0; i < count; i++) {
+      await expect(sections.nth(i)).toHaveCSS(
+        "scroll-snap-align",
+        "center"
+      );
+    }
+
+    // The intro/terminal heading must NOT be inside the snap container —
+    // reading it must never be interrupted by the manifesto's snap.
+    await expect(
+      page
+        .locator(".manifesto-slider")
+        .getByRole("heading", { name: "Creative Tools for Nerds" })
+    ).toHaveCount(0);
   });
 
-  test("does not snap under prefers-reduced-motion", async ({ page }) => {
+  test("is keyboard-reachable and keyboard-scrollable (#413)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const slider = page.locator(".manifesto-slider");
+    await expect(slider).toHaveAttribute("tabindex", "0");
+    await expect(slider).toHaveAccessibleName(/manifesto/i);
+
+    const cta = page.getByRole("link", { name: "Launch /tools →" });
+    await expect(cta).not.toBeInViewport();
+
+    await slider.focus();
+    await page.keyboard.press("End");
+    await expect(cta).toBeInViewport({ timeout: 3000 });
+  });
+
+  test("snap is disabled under prefers-reduced-motion", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/");
-    const target = await centerOf(page, 1);
 
-    await page.evaluate((y) => window.scrollTo(0, y), target - 120);
-    await page.waitForTimeout(700);
-
-    const settled = await page.evaluate(() => window.scrollY);
-    expect(settled).toBe(target - 120);
+    await expect(page.locator(".manifesto-slider")).toHaveCSS(
+      "scroll-snap-type",
+      "none"
+    );
   });
 });


### PR DESCRIPTION
## Summary
Closes #536.

Every previous attempt at the homepage manifesto snap (#527, #534) tried to make the *document* scroll snap — either CSS `scroll-snap-type` on `document.scrollingElement`, or a hand-rolled JS "ease to whichever section you settled in / page-commit." Both proved unreliable in practice ("still not good" / "still snappy... still").

You found a working real-world reference ([freefrontend.com/css-scroll-snap](https://freefrontend.com/css-scroll-snap/)) and the [MDN scroll-snap guide](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll_snap) confirms the same thing: CSS scroll-snap is only reliable when it's on the actual dedicated `overflow: auto/scroll` container, not the document. So I ported that pattern instead of hand-rolling another approximation.

## Changes
- The manifesto sections (not the intro/terminal — reading that must never be interrupted) now live inside their own `.manifesto-slider`: `height: 100dvh; overflow-y: auto; scroll-snap-type: y mandatory`.
- No sticky positioning or JS is needed to make it "take over" scrolling — this is standard scroll-chaining: the browser already routes wheel/touch input to whichever scrollable element is under the pointer first, only falling through to continue scrolling the outer page once the slider's own scroll is exhausted.
- **Deleted** the JS ease-to-section/page-commit logic from #534 entirely — no longer needed once real native snap is doing the work.
- Kept the dot rail exactly as-is (per your request — not the reference's `01/02/03` indicator), and kept the sticky reveal from #531 unchanged. Both are driven by the same `IntersectionObserver`, which works identically regardless of document vs. nested scroll containers.
- **Fixed the thing that made this exact pattern painful in #413 last time it was tried**: a nested scroll container isn't independently keyboard-reachable unless it's focusable. Added `tabIndex={0}` + an accessible name to the slider (matching #413's own suggested fix, and the same thing MDN's guide points at — "keyboard-only scrolling areas"). Verified via Tab-order diagnostics: it's reachable as tab stop #6, and once focused, End/PageDown/Home all work natively and reliably.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **160/160**
- [x] Rewrote `scroll-snap.spec.ts` around the new container: CSS declarations (now functionally meaningful, since they're on the real scroll container) + a keyboard-driven settle test, which is deterministic — confirmed via diagnostics that focused `End` reliably reaches exact max scroll (just needs ~1.5s to fully settle)
- [x] Updated `homepage.spec.ts`'s keyboard-reachability test to focus the slider first, matching how a real keyboard user reaches it (Tab stop #6)

**Note on wheel-triggered settling**: same finding as #527 — synthetic wheel events via Playwright/CDP don't reliably trigger Chromium's snap-settle correction in headless mode, even on a proper native `overflow` container (tried both a single big wheel jump and several small incremental ticks simulating trackpad input; both stayed at `scrollTop: 0`). This is a known CDP/headless limitation around momentum/fling detection, not a sign of malfunction — keyboard-driven scrolling through the *same* CSS settles perfectly, and this is now real native browser scroll-snap rather than a custom approximation, so I have much higher confidence it'll actually work for real wheel/trackpad input than either of the previous two attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)