### PR TITLE
fix: start the manifesto snap slider from the intro, not after it

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import CirclesBackground from "./CirclesBackground";
+import TerminalIntro from "./TerminalIntro";
 
 const ideas = [
   {
@@ -161,6 +163,10 @@ export default function ManifestoScroll() {
         tabIndex={0}
         aria-label="Manifesto: what nobuddy.org is about"
       >
+        <section className="min-h-screen snap-center">
+          <CirclesBackground variant="home" />
+          <TerminalIntro />
+        </section>
         <div className="manifesto-gradient">
           {ideas.map((idea, i) => (
             <ManifestoSection

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -68,8 +68,10 @@ html {
    JS to "take over" scrolling: the browser's own scroll-chaining already
    sends wheel/touch input to whichever scrollable element is under the
    pointer first, only falling through to the outer page once this
-   container's own scroll is exhausted. The intro/terminal section lives
-   outside this element entirely, so reading it is never interrupted.
+   container's own scroll is exhausted. The intro/terminal section is this
+   container's first page (native mandatory snap only responds to an
+   actual scroll gesture — it never auto-advances while stationary — so
+   reading it still can't be interrupted mid-read).
 
    A nested scroll container isn't independently reachable by keyboard
    scrolling unless it's focusable — see the tabIndex + aria-label on

--- a/web-buddy/src/app/page.tsx
+++ b/web-buddy/src/app/page.tsx
@@ -1,11 +1,9 @@
-import TerminalIntro from "./components/TerminalIntro";
 import ManifestoScroll from "./components/ManifestoScroll";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import JsonLd, { type JsonLdData } from "./components/JsonLd";
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "./constants";
 import { createMetadata } from "./metadata";
-import CirclesBackground from "./components/CirclesBackground";
 
 const title = SITE_NAME;
 const slug = "/";
@@ -33,10 +31,6 @@ export default function HomePage() {
       <JsonLd id="jsonld-home" data={jsonLd} />
       <Header />
       <main className="text-black dark:text-white overflow-x-hidden">
-        <section className="min-h-screen">
-          <CirclesBackground variant="home" />
-          <TerminalIntro />
-        </section>
         <ManifestoScroll />
       </main>
       <Footer />

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -10,7 +10,7 @@ import { test, expect } from "@playwright/test";
 // correctly declared plus the keyboard-driven settle, which *is*
 // deterministic and directly observable.
 test.describe("homepage manifesto scroll snap", () => {
-  test("the manifesto has its own snap container, separate from the intro", async ({
+  test("the intro is the snap container's first page, ideas/CTA follow", async ({
     page,
   }) => {
     await page.goto("/");
@@ -18,6 +18,13 @@ test.describe("homepage manifesto scroll snap", () => {
     const slider = page.locator(".manifesto-slider");
     await expect(slider).toHaveCSS("overflow-y", "auto");
     await expect(slider).toHaveCSS("scroll-snap-type", "y mandatory");
+
+    // Paging starts from the very first scroll: the intro is a snap page
+    // in the same container, not separate document-flow content the user
+    // has to scroll past on their own before paging kicks in.
+    await expect(
+      slider.getByRole("heading", { name: "Creative Tools for Nerds" })
+    ).toBeAttached();
 
     const sections = page.locator(".manifesto-slider .manifesto-section");
     const count = await sections.count();
@@ -28,14 +35,6 @@ test.describe("homepage manifesto scroll snap", () => {
         "center"
       );
     }
-
-    // The intro/terminal heading must NOT be inside the snap container —
-    // reading it must never be interrupted by the manifesto's snap.
-    await expect(
-      page
-        .locator(".manifesto-slider")
-        .getByRole("heading", { name: "Creative Tools for Nerds" })
-    ).toHaveCount(0);
   });
 
   test("is keyboard-reachable and keyboard-scrollable (#413)", async ({


### PR DESCRIPTION
## Summary
Closes #539.

#536's slider only wrapped the 4 idea sections + CTA — the terminal/hero intro sat outside it in normal document flow, so page-scroll snapping only kicked in once you'd already scrolled past the intro on your own: "I must scroll down to the teddy bear and only then page scrolling starts."

## Changes
- Moved `TerminalIntro` + `CirclesBackground` into `ManifestoScroll` as the slider's first page — its own `<section className="min-h-screen snap-center">`, but deliberately kept **outside** `.manifesto-gradient` so the existing emoji-fade-in mask (#531) and the circles' own visuals are untouched. Confirmed via a screenshot that nothing gets swallowed by the gradient's z-stacking.
- Native `mandatory` snap only responds to an actual scroll gesture and never auto-advances while stationary, so this only changes **when paging starts** — not whether reading the intro can be interrupted. Same guarantee as every prior iteration, it just no longer requires the intro to live outside the container to get it.
- `page.tsx` simplifies to `<Header /><main><ManifestoScroll /></main><Footer />` now that `ManifestoScroll` owns the whole homepage scroll experience.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **160/160**
- [x] Updated `scroll-snap.spec.ts`'s structural assertion (intro now correctly asserted as *inside* `.manifesto-slider` — the previous PR asserted the opposite, which was correct for that PR but is exactly what this one changes)
- [x] Screenshot check: circles background, terminal box, and the floating-emoji peek-through all render correctly with no stacking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)