### PR TITLE
fix: tighten mobile homepage — smaller intro/header, one-line footer, and a real footer-overlap bug

### DIFF
--- a/web-buddy/src/app/components/Footer.tsx
+++ b/web-buddy/src/app/components/Footer.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { AUTHOR_NAME, GITHUB_URL } from "../constants";
+import { AUTHOR_NAME } from "../constants";
 
 export default function Footer() {
   return (
-    <footer className="fixed bottom-0 left-0 w-full z-50 bg-white/80 dark:bg-black/80 backdrop-blur-sm border-t border-gray-200 dark:border-gray-800 py-3 md:py-6 text-center text-sm text-gray-600 dark:text-gray-400 px-4 sm:px-6">
+    <footer className="fixed bottom-0 left-0 w-full z-50 bg-white/80 dark:bg-black/80 backdrop-blur-sm border-t border-gray-200 dark:border-gray-800 py-2 sm:py-3 md:py-4 text-center text-xs sm:text-sm text-gray-600 dark:text-gray-400 px-4 sm:px-6">
       <p>
         Crafted with ♥️ by{" "}
         <Link
@@ -12,17 +12,7 @@ export default function Footer() {
           title="home"
         >
           {AUTHOR_NAME}
-        </Link>{" "}
-        • Open source on{" "}
-        <a
-          href={GITHUB_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="underline hover:text-black dark:hover:text-white transition"
-          title="github"
-        >
-          GitHub
-        </a>
+        </Link>
       </p>
     </footer>
   );

--- a/web-buddy/src/app/components/Header.tsx
+++ b/web-buddy/src/app/components/Header.tsx
@@ -5,10 +5,10 @@ import { AUTHOR_NAME, GITHUB_URL } from "../constants";
 export default function Header() {
   return (
     <header className="fixed top-0 left-0 w-full z-50 bg-white/80 dark:bg-black/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-900">
-      <nav className="max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between h-12 md:h-16 overflow-hidden">
+      <nav className="max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between h-10 sm:h-12 md:h-16 overflow-hidden">
         <Link
           href="/"
-          className="text-2xl font-extrabold tracking-tight text-black dark:text-white"
+          className="text-lg sm:text-2xl font-extrabold tracking-tight text-black dark:text-white"
         >
           <Image
             src="/logo-header.webp"
@@ -23,7 +23,7 @@ export default function Header() {
           />
           {AUTHOR_NAME}
         </Link>
-        <div className="flex flex-wrap items-center space-x-4 sm:space-x-6">
+        <div className="flex flex-wrap items-center space-x-3 sm:space-x-6 text-sm sm:text-base">
           <Link
             href="/tools"
             className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white font-semibold transition"

--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -94,7 +94,7 @@ function ManifestoSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section min-h-screen snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section min-h-[var(--page-h)] snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-emoji text-6xl mb-6">{emoji}</div>
       <h2 className="text-2xl sm:text-3xl font-bold mb-4">{title}</h2>
@@ -115,7 +115,7 @@ function CallToActionSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section h-screen snap-center flex flex-col justify-center items-center text-center p-10 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section h-[var(--page-h)] snap-center flex flex-col justify-center items-center text-center p-10 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-cta-text text-xl sm:text-2xl mb-6">
         Explore the tools. Adopt a Buddy.
@@ -163,7 +163,7 @@ export default function ManifestoScroll() {
         tabIndex={0}
         aria-label="Manifesto: what nobuddy.org is about"
       >
-        <section className="min-h-screen snap-center">
+        <section className="min-h-[var(--page-h)] snap-center">
           <CirclesBackground variant="home" />
           <TerminalIntro />
         </section>

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -93,22 +93,25 @@ const lastFrame = frames.length - 1;
 function Hero() {
   return (
     <section
-      className="relative pb-5 md:pb-20 max-w-4xl mx-auto px-4 md:px-6 text-center"
+      className="relative pb-3 sm:pb-5 md:pb-10 max-w-4xl mx-auto px-4 md:px-6 text-center"
       aria-label="Introduction section"
     >
-      <h1 className="relative z-10 text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-6 text-black dark:text-white">
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-base sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-6 md:mb-8">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-4 sm:mb-6 md:mb-8">
         {SITE_DESCRIPTION}
       </h2>
 
+      {/* Skipped on mobile portrait: the intro is already tight on
+          vertical space there, and this action is one tap away in the
+          header's own GitHub link. */}
       <Link
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-6 py-2.5 md:px-8 md:py-3 text-sm sm:text-base rounded-full shadow-lg hover:bg-gray-900 dark:hover:bg-gray-100 transition"
+        className="hidden sm:inline-block relative z-10 bg-black dark:bg-white text-white dark:text-black font-semibold px-6 py-2.5 md:px-8 md:py-3 text-sm sm:text-base rounded-full shadow-lg hover:bg-gray-900 dark:hover:bg-gray-100 transition"
         aria-label="Follow Nobuddyorg on GitHub"
         title="follow on github"
       >
@@ -162,17 +165,17 @@ export default function TerminalIntro() {
   const isWaiting = frameIndex === lastFrame;
 
   return (
-    <div className="flex flex-col items-center px-4 pt-20 md:pt-32">
+    <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-24">
       <Hero />
 
-      <div className="w-full max-w-3xl min-h-[340px] rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a] mb-10">
+      <div className="w-full max-w-3xl min-h-[220px] sm:min-h-[280px] md:min-h-[280px] rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a] mb-6 sm:mb-8 md:mb-10">
         <div className="flex items-center space-x-2 px-3 py-2 bg-[#2d2d2d] border-b border-neutral-700">
           <div className="w-3 h-3 rounded-full bg-red-500"></div>
           <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
           <div className="w-3 h-3 rounded-full bg-green-500"></div>
         </div>
 
-        <div className="py-10 px-6 font-mono text-green-400 text-lg bg-[#1a1a1a] text-left">
+        <div className="py-5 sm:py-7 md:py-10 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-sm sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           {lines.map((line, i) => (
             <div key={i} className="fade-in-up whitespace-pre" style={fadeInStyle}>
               {line.role === "cmd" && (

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -76,12 +76,37 @@ html {
    A nested scroll container isn't independently reachable by keyboard
    scrolling unless it's focusable — see the tabIndex + aria-label on
    ManifestoScroll's wrapper div, matching #413's own suggested fix for
-   this exact pattern. */
+   this exact pattern.
+
+   --page-h (not 100dvh directly): Footer is fixed site-wide, and unlike
+   every other page here, the slider fills the viewport edge to edge with
+   no bottom padding of its own — so a plain 100dvh page would render its
+   last ~40px under the fixed footer. --page-h reserves that space, and
+   every page (this section, .manifesto-section, the CTA) sizes off it via
+   min-h-[var(--page-h)]/h-[var(--page-h)] instead of Tailwind's
+   min-h-screen/h-screen (100vh) so they can't independently drift back to
+   the un-reserved viewport height. A custom property, rather than sizing
+   .manifesto-gradient itself, is what lets that inheritance reach the
+   ideas/CTA sections cleanly: .manifesto-gradient has to stay auto-height
+   (it's exactly as tall as its 5 stacked children, which is what makes
+   there something to scroll through), and a percentage height on its
+   children wouldn't resolve against an auto-height ancestor. */
 .manifesto-slider {
+  --page-h: calc(100dvh - 2.25rem);
   height: 100dvh;
   overflow-y: auto;
   scroll-snap-type: y mandatory;
   scrollbar-width: none;
+}
+@media (min-width: 640px) {
+  .manifesto-slider {
+    --page-h: calc(100dvh - 2.75rem);
+  }
+}
+@media (min-width: 768px) {
+  .manifesto-slider {
+    --page-h: calc(100dvh - 3.5rem);
+  }
 }
 .manifesto-slider::-webkit-scrollbar {
   display: none;

--- a/web-buddy/tests/dark-mode-hover.spec.ts
+++ b/web-buddy/tests/dark-mode-hover.spec.ts
@@ -32,25 +32,21 @@ test.describe("dark mode hover contrast", () => {
     expect(await contrastRatio(page, bg, color)).toBeGreaterThanOrEqual(4.5);
   });
 
-  test("footer links stay readable on hover in dark mode", async ({
+  test("footer link stays readable on hover in dark mode", async ({
     page,
   }) => {
     await page.goto("/");
 
-    for (const name of ["nobuddy", "GitHub"]) {
-      const link = page.locator("footer a", { hasText: name }).first();
-      await link.hover();
-      await page.waitForTimeout(TRANSITION_SETTLE_MS);
-      const color = await link.evaluate(
-        (node) => getComputedStyle(node).color
-      );
-      const footerBg = await page
-        .locator("footer")
-        .evaluate((node) => getComputedStyle(node).backgroundColor);
+    const link = page.locator("footer a", { hasText: "nobuddy" }).first();
+    await link.hover();
+    await page.waitForTimeout(TRANSITION_SETTLE_MS);
+    const color = await link.evaluate((node) => getComputedStyle(node).color);
+    const footerBg = await page
+      .locator("footer")
+      .evaluate((node) => getComputedStyle(node).backgroundColor);
 
-      expect(
-        await contrastRatio(page, footerBg, color)
-      ).toBeGreaterThanOrEqual(4.5);
-    }
+    expect(await contrastRatio(page, footerBg, color)).toBeGreaterThanOrEqual(
+      4.5
+    );
   });
 });

--- a/web-buddy/tests/footer-home-link.spec.ts
+++ b/web-buddy/tests/footer-home-link.spec.ts
@@ -13,13 +13,4 @@ test.describe("footer home link", () => {
     await homeLink.click();
     await expect(page).toHaveURL(/\/$/);
   });
-
-  test("GitHub link still opens in a new tab", async ({ page }) => {
-    await page.goto("/");
-
-    const githubLink = page.getByRole("contentinfo").getByRole("link", {
-      name: "GitHub",
-    });
-    await expect(githubLink).toHaveAttribute("target", "_blank");
-  });
 });

--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -29,9 +29,11 @@ test.describe("homepage hero and manifesto content", () => {
         "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps."
       )
     ).toBeVisible();
+    // Hidden on mobile portrait to keep the intro compact (#541) — still
+    // one tap away via the header's own GitHub link.
     await expect(
       page.getByRole("link", { name: "Follow Nobuddyorg on GitHub" })
-    ).toBeVisible();
+    ).not.toBeVisible();
   });
 
   test("manifesto sections are reachable via keyboard scrolling", async ({

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -63,4 +63,33 @@ test.describe("homepage manifesto scroll snap", () => {
       "none"
     );
   });
+
+  // Footer is fixed site-wide, and unlike every other page here the slider
+  // fills the viewport edge to edge with no bottom padding of its own — a
+  // plain 100dvh page would render its last ~40px under the fixed footer
+  // (#541). Each page sizes off --page-h (globals.css), which reserves
+  // that space; this locks in a real clearance instead of just trusting
+  // the reserved amount matches the footer's actual rendered height.
+  for (const viewport of [
+    { width: 320, height: 568, label: "small mobile" },
+    { width: 375, height: 812, label: "mobile" },
+    { width: 1280, height: 800, label: "desktop" },
+  ]) {
+    test(`the intro page doesn't render under the fixed footer (${viewport.label})`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto("/");
+
+      const footerTop = await page
+        .locator("footer")
+        .evaluate((el) => el.getBoundingClientRect().top);
+      const introBottom = await page
+        .locator(".manifesto-slider section")
+        .first()
+        .evaluate((el) => el.getBoundingClientRect().bottom);
+
+      expect(footerTop - introBottom).toBeGreaterThanOrEqual(0);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
Closes #541.

### Explicit asks
- Hero title/subtitle shrink further on mobile (`text-3xl`/`text-sm` at the smallest breakpoint, was `text-5xl`/`text-base`).
- "Follow on GitHub" hero button hidden on mobile portrait (`hidden sm:inline-block`) — still one tap away via the header's own GitHub link.
- Header nav/logo text and height shrink on mobile (`h-10`, smaller logo text, smaller nav links).
- Footer trimmed to one line: dropped "• Open source on GitHub" (already reachable from the header nav and the hero button), smaller text/padding.
- Terminal box more compact — smaller min-height, padding, and text size. Ended up touching all three breakpoints, not just mobile — see the bug below for why.

### Bug found while verifying (not mobile-specific — present since #536/#539, just never noticed)
`Footer` is `position: fixed` site-wide, and every other page (`/tools`, `/about`, tool pages) reserves bottom padding for it via `ToolPageShell`. The homepage's new full-height snap slider (#536) has no such reservation — so the fixed footer rendered **over the last ~40-70px of every single page in the slider, intro included, at every viewport size**. Confirmed via exact pixel measurement: `footerTop < introSectionBottom` before the fix, a clean 3px clearance after, checked from 320×568 up through 1440×900.

Fixed by reserving that space through a `--page-h` custom property on `.manifesto-slider` (`calc(100dvh - <footer-height>)`, tuned per breakpoint) that every page now sizes off via `min-h-[var(--page-h)]`/`h-[var(--page-h)]` instead of Tailwind's `min-h-screen`/`h-screen`. A custom property — rather than just sizing `.manifesto-gradient` itself — is what lets that reservation reach the ideas/CTA sections cleanly: `.manifesto-gradient` has to stay auto-height (it's exactly as tall as its 5 stacked children, which is what makes there something to scroll through), and a percentage height on its children wouldn't resolve against an auto-height ancestor. Closing the reserved gap also required trimming the desktop terminal/hero sizing a bit, which is why "compacter" ended up applying everywhere rather than mobile alone.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **162/162**
- [x] New regression test asserting real clearance between the intro and the fixed footer at three viewport sizes (320×568, 375×812, 1280×800) — this is a pixel-measurement test, not just a CSS-declaration check, since the bug was specifically that the reserved amount didn't match the footer's real rendered height
- [x] Updated tests for intentional behavior changes: mobile GitHub button now asserted hidden (was visible), footer GitHub-link hover test removed (link no longer exists there)
- [x] Screenshots at 320×568, 375×812, and 1280×800 confirming no overlap and everything readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)