### PR TITLE
fix: terminal box height jump and horizontal overflow on mobile

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -175,9 +175,13 @@ export default function TerminalIntro() {
           <div className="w-3 h-3 rounded-full bg-green-500"></div>
         </div>
 
-        <div className="py-5 sm:py-7 md:py-10 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-sm sm:text-base md:text-lg bg-[#1a1a1a] text-left">
+        <div className="py-5 sm:py-7 md:py-10 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           {lines.map((line, i) => (
-            <div key={i} className="fade-in-up whitespace-pre" style={fadeInStyle}>
+            <div
+              key={i}
+              className="fade-in-up whitespace-pre-wrap break-words"
+              style={fadeInStyle}
+            >
               {line.role === "cmd" && (
                 <>
                   <span className="text-blue-400">nobuddy</span>
@@ -187,13 +191,18 @@ export default function TerminalIntro() {
               {line.text}
             </div>
           ))}
-          {isWaiting && (
-            <div className="fade-in-up mt-8" style={fadeInStyle}>
-              <span className="text-yellow-400 animate-pulse motion-reduce:animate-none">
-                Scroll down to continue...
-              </span>
-            </div>
-          )}
+          {/* Always rendered (space reserved via `invisible`, not
+              conditionally mounted) so the box doesn't grow the moment
+              this line becomes real — it fades in into space that was
+              already there. */}
+          <div
+            className={`mt-8 ${isWaiting ? "fade-in-up" : "invisible"}`}
+            style={fadeInStyle}
+          >
+            <span className="text-yellow-400 animate-pulse motion-reduce:animate-none">
+              Scroll down to continue...
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -90,11 +90,20 @@ html {
    ideas/CTA sections cleanly: .manifesto-gradient has to stay auto-height
    (it's exactly as tall as its 5 stacked children, which is what makes
    there something to scroll through), and a percentage height on its
-   children wouldn't resolve against an auto-height ancestor. */
+   children wouldn't resolve against an auto-height ancestor.
+
+   overflow-x: hidden is required, not cosmetic: per spec, setting only
+   overflow-y to a non-visible value promotes the other axis from visible
+   to auto too, so without this the slider silently becomes its own
+   horizontally-scrollable region. It was carrying CirclesBackground's
+   deliberately oversized decorative SVG (100rem/1600px wide, meant to be
+   clipped by body's own overflow-x: hidden) as ~600px of scrollable dead
+   space — "I can scroll right but there's nothing there" (#546). */
 .manifesto-slider {
   --page-h: calc(100dvh - 2.25rem);
   height: 100dvh;
   overflow-y: auto;
+  overflow-x: hidden;
   scroll-snap-type: y mandatory;
   scrollbar-width: none;
 }

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -92,4 +92,19 @@ test.describe("homepage manifesto scroll snap", () => {
       expect(footerTop - introBottom).toBeGreaterThanOrEqual(0);
     });
   }
+
+  // Only overflow-y was set, and per spec that silently promotes
+  // overflow-x from visible to auto too — turning any oversized
+  // descendant (CirclesBackground's deliberately 100rem-wide decorative
+  // SVG, previously safely clipped by body's own overflow-x: hidden) into
+  // real horizontally-scrollable dead space (#546).
+  test("the slider can't be scrolled horizontally", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+
+    await expect(page.locator(".manifesto-slider")).toHaveCSS(
+      "overflow-x",
+      "hidden"
+    );
+  });
 });

--- a/web-buddy/tests/terminal-skip.spec.ts
+++ b/web-buddy/tests/terminal-skip.spec.ts
@@ -45,4 +45,38 @@ test.describe("terminal intro skip and session persistence", () => {
       page.getByText("Scroll down to continue...")
     ).toBeVisible({ timeout: 500 });
   });
+
+  test("terminal box height is stable once all lines are showing (#546)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/");
+
+    await page.getByText("You’ve reached").waitFor({ timeout: 10000 });
+    const box = page.locator(".font-mono").locator("..");
+    const midHeight = (await box.boundingBox())!.height;
+
+    await expect(page.getByText("Scroll down to continue...")).toBeVisible({
+      timeout: 5000,
+    });
+    const finalHeight = (await box.boundingBox())!.height;
+
+    expect(finalHeight).toBe(midHeight);
+  });
+
+  test("terminal lines don't overflow their box on narrow viewports (#546)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto("/");
+    await page.mouse.click(10, 10);
+    await expect(
+      page.getByText("Scroll down to continue...")
+    ).toBeVisible({ timeout: 1000 });
+
+    const overflow = await page
+      .locator(".font-mono")
+      .evaluate((el) => el.scrollWidth - el.clientWidth);
+    expect(overflow).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
Closes #546.

Two bugs, from "the terminal gets a bit bigger after last line gets visible... on mobile i can scroll to the right but there is nothing":

### 1. Box height jump
Measured `220px → 243px` the moment "Scroll down to continue..." rendered — its wrapper was conditionally mounted (`{isWaiting && <div>...}`), so it only started occupying layout space once `isWaiting` flipped true. Fixed by always rendering it (space reserved via `invisible`, not `display:none`, so it stays excluded from the a11y tree the same way until then) and only toggling visibility + the reveal animation. Verified **zero** height delta between "all 6 lines shown" and "scroll message visible" across 320px/375px/1280px-wide viewports — my first measurement attempt showed a false-positive delta because a fixed 2s timeout landed mid-animation (the real animation runs ~5.2s), not because the fix didn't work.

### 2. Horizontal overflow, nothing to see when scrolling right
The terminal text's own `scrollWidth` exceeded its `clientWidth` — lines were getting cut off ("reduce text for width per line"). Fixed by shrinking mobile text further (`text-sm` → `text-xs`) and switching `whitespace-pre` → `whitespace-pre-wrap break-words` so any remaining overflow wraps instead of clipping.

The bigger part of "scroll right, nothing there" turned out to be `.manifesto-slider` itself: it only sets `overflow-y`, and per spec that silently promotes `overflow-x` from `visible` to `auto` too — so `CirclesBackground`'s deliberately oversized decorative SVG (`100rem`/1600px, previously safely clipped by `body`'s own `overflow-x: hidden`) was leaking through as ~600px of real horizontally-scrollable dead space now that it sits inside a new nested scroll container (#536). Fixed with an explicit `overflow-x: hidden` on the slider.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **165/165**
- [x] New tests for box-height stability, zero line overflow, and the slider's `overflow-x`, all keyed to actual content appearing (`waitForSelector`) rather than fixed timeouts — the investigation above showed a fixed-timeout check can land mid-animation and produce a misleading "still growing" reading
- [x] Screenshots at 320×568 confirming full lines readable, wrapped gracefully, no visible jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)