### PR TITLE
feat: dot for the intro page, glowing scroll-hint arrow (#544)

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -27,7 +27,7 @@ const ideas = [
   },
 ];
 
-const sectionCount = ideas.length + 1; // + call-to-action
+const sectionCount = ideas.length + 2; // + intro + call-to-action
 
 // One shared observer drives both the reveal animation and the dot rail —
 // `active` tracks whichever section is currently centered (for the dots),
@@ -163,22 +163,22 @@ export default function ManifestoScroll() {
         tabIndex={0}
         aria-label="Manifesto: what nobuddy.org is about"
       >
-        <section className="min-h-[var(--page-h)] snap-center">
+        <section className="min-h-[var(--page-h)] snap-center" ref={register(0)}>
           <CirclesBackground variant="home" />
-          <TerminalIntro />
+          <TerminalIntro active={active[0]} />
         </section>
         <div className="manifesto-gradient">
           {ideas.map((idea, i) => (
             <ManifestoSection
               key={idea.title}
-              register={register(i)}
-              revealed={revealed[i]}
+              register={register(i + 1)}
+              revealed={revealed[i + 1]}
               {...idea}
             />
           ))}
           <CallToActionSection
-            register={register(ideas.length)}
-            revealed={revealed[ideas.length]}
+            register={register(ideas.length + 1)}
+            revealed={revealed[ideas.length + 1]}
           />
         </div>
       </div>

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -90,6 +90,21 @@ function buildFrames(): Frame[] {
 const frames = buildFrames();
 const lastFrame = frames.length - 1;
 
+// Both hints at and performs the page-by-page snap scroll, so the
+// paging behavior itself is discoverable (#544) rather than something a
+// visitor has to stumble into via a wheel gesture.
+function scrollToNextPage(button: HTMLElement) {
+  const slider = button.closest<HTMLElement>(".manifesto-slider");
+  if (!slider) return;
+  const reduceMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  slider.scrollBy({
+    top: slider.clientHeight,
+    behavior: reduceMotion ? "auto" : "smooth",
+  });
+}
+
 function LineText({ line }: { line: ScriptLine }) {
   return (
     <>
@@ -107,14 +122,14 @@ function LineText({ line }: { line: ScriptLine }) {
 function Hero() {
   return (
     <section
-      className="relative pb-3 sm:pb-5 md:pb-10 max-w-4xl mx-auto px-4 md:px-6 text-center"
+      className="relative pb-3 sm:pb-5 md:pb-8 max-w-4xl mx-auto px-4 md:px-6 text-center"
       aria-label="Introduction section"
     >
-      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-6 text-black dark:text-white">
+      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-4 text-black dark:text-white">
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-6">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-4">
         {SITE_DESCRIPTION}
       </h2>
 
@@ -135,7 +150,7 @@ function Hero() {
   );
 }
 
-export default function TerminalIntro() {
+export default function TerminalIntro({ active }: { active: boolean }) {
   const [frameIndex, setFrameIndex] = useState(0);
 
   // Render the completed terminal instantly on repeat visits within the
@@ -179,10 +194,10 @@ export default function TerminalIntro() {
   const isWaiting = frameIndex === lastFrame;
 
   return (
-    <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-24">
+    <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-20">
       <Hero />
 
-      <div className="w-full max-w-3xl rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a] mb-6 sm:mb-8 md:mb-8">
+      <div className="w-full max-w-3xl mb-6 sm:mb-8 md:mb-6 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
         <div className="flex items-center space-x-2 px-3 py-2 bg-[#2d2d2d] border-b border-neutral-700">
           <div className="w-3 h-3 rounded-full bg-red-500"></div>
           <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
@@ -195,7 +210,7 @@ export default function TerminalIntro() {
             which is what's growing line by line. Without this, the box
             visibly grows throughout the whole typing animation, not just
             at the final line. */}
-        <div className="grid py-5 sm:py-8 md:py-8 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
+        <div className="grid py-5 sm:py-8 md:py-6 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           <div aria-hidden="true" className="invisible [grid-area:1/1]">
             {frames[lastFrame].lines.map((line, i) => (
               <div key={i} className="whitespace-pre-wrap break-words">
@@ -225,6 +240,38 @@ export default function TerminalIntro() {
           </div>
         </div>
       </div>
+
+      {/* Fixed to the viewport, not anchored below the terminal: the
+          intro's own content height is already tuned right up against
+          the footer-clearance budget every viewport size has to fit
+          within (#541/#546/#548), so anything that adds to *that* flow
+          re-blows the budget on shorter viewports (confirmed: broke it
+          again at 1280x720 — Playwright's own default test viewport —
+          on the first attempt). A fixed position costs nothing in that
+          budget regardless of content height. Gated on `active` (this
+          page is the one currently in view) so it doesn't stay pinned on
+          screen once scrolled past the intro. */}
+      <button
+        type="button"
+        onClick={(e) => scrollToNextPage(e.currentTarget)}
+        aria-label="Scroll to the next page"
+        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 ${active && isWaiting ? "fade-in-up" : "invisible"}`}
+        style={fadeInStyle}
+      >
+        <svg
+          width="26"
+          height="26"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -295,3 +295,77 @@ html {
     transition: none;
   }
 }
+
+/* Glowing scroll-hint chevron pinned near the bottom of the viewport
+   (position: fixed, applied via a Tailwind class in the JSX — not set
+   here, so it isn't shadowed by this rule's own cascade position) while
+   the intro is the active page: hints at *and* performs the page-by-page
+   snap scroll on click, so the paging behavior itself is discoverable
+   (#544) rather than something a visitor has to stumble into via a wheel
+   gesture. The glow is a blurred radial-gradient pseudo-element behind
+   the icon (not a box-shadow) so it can bloom past the button's own
+   small box without clipping — it needs the button to be a positioned
+   ancestor, which the fixed positioning already provides.
+
+   Cyan-to-violet (not amber): the intro sits on CirclesBackground's warm
+   amber palette, and an amber/yellow glow (matching the terminal's own
+   yellow "Scroll down" text) all but disappears against it — confirmed
+   via a cropped screenshot, not just reasoning about it. A cool-toned
+   glow contrasts regardless of theme, and the icon itself rides on a
+   translucent --background disc so it stays legible over every stop of
+   the amber gradient, not just the ones it happens to contrast with.
+
+   Only the glow pulses (opacity/scale on ::before) — the button itself
+   doesn't bob. A continuously-translating click target never resolves to
+   a stable position, and Playwright's own click-stability wait (a decent
+   proxy for "is this annoying to click precisely") timed out against it;
+   the glow alone still reads as "alive" without moving the target. */
+.scroll-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 70%, transparent);
+  cursor: pointer;
+  /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
+     is chosen to already clear the footer without overlapping it. */
+  z-index: 60;
+}
+.scroll-hint:hover {
+  color: #06b6d4;
+}
+.scroll-hint::before {
+  content: "";
+  position: absolute;
+  inset: -0.5rem;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(34, 211, 238, 0.6),
+    rgba(167, 139, 250, 0.4) 55%,
+    transparent 75%
+  );
+  filter: blur(6px);
+  z-index: -1;
+  animation: scroll-hint-glow 1.8s ease-in-out infinite;
+}
+@keyframes scroll-hint-glow {
+  0%,
+  100% {
+    opacity: 0.35;
+    scale: 0.85;
+  }
+  50% {
+    opacity: 0.9;
+    scale: 1.15;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .scroll-hint,
+  .scroll-hint::before {
+    animation: none;
+  }
+}

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -59,21 +59,43 @@ test.describe("homepage manifesto scroll effects", () => {
     await expect(heading).toHaveCSS("opacity", "1");
   });
 
-  test("shows one dot per manifesto section, highlighting the active one as it scrolls", async ({
+  test("shows one dot per page (intro + manifesto sections), highlighting the active one as it scrolls", async ({
     page,
   }) => {
     await page.goto("/");
 
+    // The intro is a page in the slider too now (#544's own dot, so it
+    // doesn't look like "that page doesn't exist") — its dot is active
+    // immediately on load, not "nothing active until you scroll."
     const dots = page.locator(".manifesto-dot");
-    await expect(dots).toHaveCount(5);
-    await expect(page.locator(".manifesto-dot.active")).toHaveCount(0);
+    await expect(dots).toHaveCount(6);
+    await expect(dots.first()).toHaveClass(/active/, { timeout: 2000 });
+    await expect(page.locator(".manifesto-dot.active")).toHaveCount(1);
 
     const heading = page.getByRole("heading", {
       name: "Fork it, run it, improve it",
     });
     await heading.scrollIntoViewIfNeeded();
 
-    await expect(dots.nth(2)).toHaveClass(/active/, { timeout: 2000 });
+    await expect(dots.nth(3)).toHaveClass(/active/, { timeout: 2000 });
     await expect(page.locator(".manifesto-dot.active")).toHaveCount(1);
+  });
+
+  test("scroll-hint arrow below the terminal advances one page on click (#544)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForTimeout(300);
+    await page.mouse.click(200, 700);
+
+    const hint = page.getByRole("button", { name: "Scroll to the next page" });
+    await expect(hint).toBeVisible({ timeout: 2000 });
+
+    const dots = page.locator(".manifesto-dot");
+    await expect(dots.first()).toHaveClass(/active/);
+
+    await hint.click();
+
+    await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
   });
 });

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -76,9 +76,16 @@ test.describe("homepage manifesto scroll snap", () => {
   // 2016 iPhone SE 1st-gen, long discontinued, and SITE_DESCRIPTION's
   // fixed length makes an exact fit infeasible there without shrinking
   // spacing at every more common size to accommodate a legacy outlier.
+  //
+  // 1280x720 specifically: Playwright's own default chromium project
+  // viewport. #544's scroll-hint arrow silently broke this exact size
+  // (never manually checked, since 1280x800 was — a reasonable-looking
+  // choice that happened to have just enough extra height to hide the
+  // gap) until the click-to-advance test below started failing.
   for (const viewport of [
     { width: 360, height: 740, label: "small mobile" },
     { width: 375, height: 812, label: "mobile" },
+    { width: 1280, height: 720, label: "desktop (Playwright default)" },
     { width: 1280, height: 800, label: "desktop" },
   ]) {
     test(`the intro page doesn't render under the fixed footer (${viewport.label})`, async ({


### PR DESCRIPTION
## Summary
Closes #544.

### 1. Dot for the intro page
"the top most page is not visible in the dots, as if the page doesn't exist" — the intro/terminal is now registered with the same `IntersectionObserver` that already tracks the manifesto sections. Its dot lights up immediately on load, same as any other page being the active one.

### 2. Glowing scroll-hint arrow
A chevron below the terminal that both hints at and performs the page-by-page snap scroll on click, so the paging behavior itself is discoverable.

Three real bugs found and fixed while building this, not just cosmetic tuning — each confirmed empirically, not just reasoned about:
- **Invisible glow**: amber/yellow was nearly invisible against `CirclesBackground`'s own amber palette (confirmed via a cropped screenshot). Switched to a cyan-to-violet glow with the icon riding on a translucent `--background` disc so it stays legible over every stop of the gradient.
- **Unclickable button**: a continuous bob (position) animation meant the button's clickable position never stabilized — Playwright's own click-stability wait (a decent proxy for "annoying to click precisely") timed out against it. Only the glow pulses now; the icon itself holds still.
- **Hidden behind the footer**: the button silently rendered entirely *underneath* the fixed footer at **1280×720** — Playwright's own default chromium viewport, and a genuinely common resolution, not an edge case. Anchoring the arrow below the terminal added to the intro's flow height, and that content was already tuned right up against the footer-clearance budget from #541/#546/#548. Fixed by making it `position: fixed` (gated on the intro being the active page, via the same `active` state `ManifestoScroll` already tracks for the dots) instead of flow-positioned — it now costs nothing in that budget regardless of viewport height. Also closed a ~65px pre-existing gap at exactly 1280×720 that this surfaced along the way (never manually verified before — 1280×800 was tested and happened to have just enough slack to hide it).

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build`
- [x] `CI=true npx playwright test` — **167/167**
- [x] Added 1280×720 to the footer-clearance regression test's viewport list
- [x] The click-to-advance test already runs at Playwright's default (untouched) viewport — it's what actually caught the original bug, not something added after the fact
- [x] Screenshots at mobile (375) and 1280×720 confirming the dot, the arrow, legible glow, and no footer overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)