### PR TITLE
fix: scroll-hint redesign — no glow, border instead, persistent per-page button

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import CirclesBackground from "./CirclesBackground";
 import TerminalIntro from "./TerminalIntro";
+import NextPageHint from "./NextPageHint";
 
 const ideas = [
   {
@@ -94,13 +95,14 @@ function ManifestoSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section min-h-[var(--page-h)] snap-center flex flex-col justify-center items-center text-center px-6 py-10 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-6 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-emoji text-6xl mb-6">{emoji}</div>
       <h2 className="text-2xl sm:text-3xl font-bold mb-4">{title}</h2>
       <p className="max-w-xl text-base sm:text-lg text-gray-800 dark:text-gray-200">
         {body}
       </p>
+      <NextPageHint />
     </section>
   );
 }
@@ -115,7 +117,7 @@ function CallToActionSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section h-[var(--page-h)] snap-center flex flex-col justify-center items-center text-center p-10 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-10 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-cta-text text-xl sm:text-2xl mb-6">
         Explore the tools. Adopt a Buddy.
@@ -163,9 +165,9 @@ export default function ManifestoScroll() {
         tabIndex={0}
         aria-label="Manifesto: what nobuddy.org is about"
       >
-        <section className="min-h-[var(--page-h)] snap-center" ref={register(0)}>
+        <section className="min-h-dvh snap-center" ref={register(0)}>
           <CirclesBackground variant="home" />
-          <TerminalIntro active={active[0]} />
+          <TerminalIntro />
         </section>
         <div className="manifesto-gradient">
           {ideas.map((idea, i) => (

--- a/web-buddy/src/app/components/NextPageHint.tsx
+++ b/web-buddy/src/app/components/NextPageHint.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// Both hints at and performs the page-by-page snap scroll, so the paging
+// behavior itself is discoverable (#544) rather than something a visitor
+// has to stumble into via a wheel gesture.
+function scrollToNextPage(button: HTMLElement) {
+  const slider = button.closest<HTMLElement>(".manifesto-slider");
+  if (!slider) return;
+  const reduceMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  slider.scrollBy({
+    top: slider.clientHeight,
+    behavior: reduceMotion ? "auto" : "smooth",
+  });
+}
+
+// Rendered in each page's own normal flow (not a fixed overlay) so it
+// scrolls naturally with the page instead of only existing on one page
+// and blinking away everywhere else (#554).
+export default function NextPageHint() {
+  return (
+    <button
+      type="button"
+      onClick={(e) => scrollToNextPage(e.currentTarget)}
+      aria-label="Scroll to the next page"
+      className="scroll-hint"
+    >
+      <svg
+        width="26"
+        height="26"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M6 9l6 6 6-6" />
+      </svg>
+    </button>
+  );
+}

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useState } from "react";
 import type { CSSProperties } from "react";
 import { SITE_NAME, GITHUB_URL, SITE_DESCRIPTION } from "../constants";
 import Link from "next/link";
+import NextPageHint from "./NextPageHint";
 
 const SESSION_KEY = "terminalIntroPlayed";
 
@@ -90,21 +91,6 @@ function buildFrames(): Frame[] {
 const frames = buildFrames();
 const lastFrame = frames.length - 1;
 
-// Both hints at and performs the page-by-page snap scroll, so the
-// paging behavior itself is discoverable (#544) rather than something a
-// visitor has to stumble into via a wheel gesture.
-function scrollToNextPage(button: HTMLElement) {
-  const slider = button.closest<HTMLElement>(".manifesto-slider");
-  if (!slider) return;
-  const reduceMotion = window.matchMedia(
-    "(prefers-reduced-motion: reduce)"
-  ).matches;
-  slider.scrollBy({
-    top: slider.clientHeight,
-    behavior: reduceMotion ? "auto" : "smooth",
-  });
-}
-
 function LineText({ line }: { line: ScriptLine }) {
   return (
     <>
@@ -122,14 +108,14 @@ function LineText({ line }: { line: ScriptLine }) {
 function Hero() {
   return (
     <section
-      className="relative pb-3 sm:pb-5 md:pb-8 max-w-4xl mx-auto px-4 md:px-6 text-center"
+      className="relative pb-3 sm:pb-5 md:pb-4 max-w-4xl mx-auto px-4 md:px-6 text-center"
       aria-label="Introduction section"
     >
-      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-4 text-black dark:text-white">
+      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-2 text-black dark:text-white">
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-4">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-2">
         {SITE_DESCRIPTION}
       </h2>
 
@@ -150,7 +136,7 @@ function Hero() {
   );
 }
 
-export default function TerminalIntro({ active }: { active: boolean }) {
+export default function TerminalIntro() {
   const [frameIndex, setFrameIndex] = useState(0);
 
   // Render the completed terminal instantly on repeat visits within the
@@ -194,10 +180,10 @@ export default function TerminalIntro({ active }: { active: boolean }) {
   const isWaiting = frameIndex === lastFrame;
 
   return (
-    <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-20">
+    <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20">
       <Hero />
 
-      <div className="w-full max-w-3xl mb-6 sm:mb-8 md:mb-6 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
+      <div className="w-full max-w-3xl mb-6 sm:mb-8 md:mb-4 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
         <div className="flex items-center space-x-2 px-3 py-2 bg-[#2d2d2d] border-b border-neutral-700">
           <div className="w-3 h-3 rounded-full bg-red-500"></div>
           <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
@@ -210,7 +196,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
             which is what's growing line by line. Without this, the box
             visibly grows throughout the whole typing animation, not just
             at the final line. */}
-        <div className="grid py-5 sm:py-8 md:py-6 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
+        <div className="grid py-5 sm:py-8 md:py-4 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           <div aria-hidden="true" className="invisible [grid-area:1/1]">
             {frames[lastFrame].lines.map((line, i) => (
               <div key={i} className="whitespace-pre-wrap break-words">
@@ -241,37 +227,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
         </div>
       </div>
 
-      {/* Fixed to the viewport, not anchored below the terminal: the
-          intro's own content height is already tuned right up against
-          the footer-clearance budget every viewport size has to fit
-          within (#541/#546/#548), so anything that adds to *that* flow
-          re-blows the budget on shorter viewports (confirmed: broke it
-          again at 1280x720 — Playwright's own default test viewport —
-          on the first attempt). A fixed position costs nothing in that
-          budget regardless of content height. Gated on `active` (this
-          page is the one currently in view) so it doesn't stay pinned on
-          screen once scrolled past the intro. */}
-      <button
-        type="button"
-        onClick={(e) => scrollToNextPage(e.currentTarget)}
-        aria-label="Scroll to the next page"
-        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 ${active && isWaiting ? "fade-in-up" : "invisible"}`}
-        style={fadeInStyle}
-      >
-        <svg
-          width="26"
-          height="26"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
-      </button>
+      <NextPageHint />
     </div>
   );
 }

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -78,19 +78,18 @@ html {
    ManifestoScroll's wrapper div, matching #413's own suggested fix for
    this exact pattern.
 
-   --page-h (not 100dvh directly): Footer is fixed site-wide, and unlike
-   every other page here, the slider fills the viewport edge to edge with
-   no bottom padding of its own — so a plain 100dvh page would render its
-   last ~40px under the fixed footer. --page-h reserves that space, and
-   every page (this section, .manifesto-section, the CTA) sizes off it via
-   min-h-[var(--page-h)]/h-[var(--page-h)] instead of Tailwind's
-   min-h-screen/h-screen (100vh) so they can't independently drift back to
-   the un-reserved viewport height. A custom property, rather than sizing
-   .manifesto-gradient itself, is what lets that inheritance reach the
-   ideas/CTA sections cleanly: .manifesto-gradient has to stay auto-height
-   (it's exactly as tall as its 5 stacked children, which is what makes
-   there something to scroll through), and a percentage height on its
-   children wouldn't resolve against an auto-height ancestor.
+   Each page is a genuine 100dvh (Header and Footer are both fixed,
+   translucent overlays on top of it — same pattern every other route on
+   this site already uses, just with top/bottom padding sized to clear
+   them directly on each page instead of a computed height). An earlier
+   version tried to reserve chrome space via a shrunk --page-h custom
+   property sized only off the footer, on the theory that scroll-snap-
+   align: center only needed bottom clearance — wrong: centering splits
+   whatever headroom a shorter-than-100dvh page has evenly between its
+   top and bottom, so every page needed clearance from the (taller)
+   fixed header too, and never got it. That surfaced as pages overlapping
+   the header, not just the footer, only once actually measured against
+   both (#554) rather than just the one edge that had been checked before.
 
    overflow-x: hidden is required, not cosmetic: per spec, setting only
    overflow-y to a non-visible value promotes the other axis from visible
@@ -100,22 +99,11 @@ html {
    clipped by body's own overflow-x: hidden) as ~600px of scrollable dead
    space — "I can scroll right but there's nothing there" (#546). */
 .manifesto-slider {
-  --page-h: calc(100dvh - 40px);
   height: 100dvh;
   overflow-y: auto;
   overflow-x: hidden;
   scroll-snap-type: y mandatory;
   scrollbar-width: none;
-}
-@media (min-width: 640px) {
-  .manifesto-slider {
-    --page-h: calc(100dvh - 48px);
-  }
-}
-@media (min-width: 768px) {
-  .manifesto-slider {
-    --page-h: calc(100dvh - 68px);
-  }
 }
 .manifesto-slider::-webkit-scrollbar {
   display: none;
@@ -296,76 +284,38 @@ html {
   }
 }
 
-/* Glowing scroll-hint chevron pinned near the bottom of the viewport
-   (position: fixed, applied via a Tailwind class in the JSX — not set
-   here, so it isn't shadowed by this rule's own cascade position) while
-   the intro is the active page: hints at *and* performs the page-by-page
-   snap scroll on click, so the paging behavior itself is discoverable
-   (#544) rather than something a visitor has to stumble into via a wheel
-   gesture. The glow is a blurred radial-gradient pseudo-element behind
-   the icon (not a box-shadow) so it can bloom past the button's own
-   small box without clipping — it needs the button to be a positioned
-   ancestor, which the fixed positioning already provides.
+/* Scroll-hint chevron, rendered once per page (intro + each manifesto
+   idea — not the CTA, which has its own action) in that page's own
+   normal flow, not a fixed overlay: it scrolls naturally with whichever
+   page it's on instead of only existing on the intro and blinking away
+   everywhere else (#554). Both hints at and performs the page-by-page
+   snap scroll on click — see NextPageHint.tsx.
 
-   Cyan-to-violet (not amber): the intro sits on CirclesBackground's warm
-   amber palette, and an amber/yellow glow (matching the terminal's own
-   yellow "Scroll down" text) all but disappears against it — confirmed
-   via a cropped screenshot, not just reasoning about it. A cool-toned
-   glow contrasts regardless of theme, and the icon itself rides on a
-   translucent --background disc so it stays legible over every stop of
-   the amber gradient, not just the ones it happens to contrast with.
-
-   Only the glow pulses (opacity/scale on ::before) — the button itself
-   doesn't bob. A continuously-translating click target never resolves to
-   a stable position, and Playwright's own click-stability wait (a decent
-   proxy for "is this annoying to click precisely") timed out against it;
-   the glow alone still reads as "alive" without moving the target. */
+   Border, not a glow: a previous glow version was nearly invisible
+   against CirclesBackground's amber palette and looked overwrought once
+   actually seen live. border-color matches the icon's own color
+   (--foreground) so it reads as one shape in either theme. */
 .scroll-hint {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 2.5rem;
   height: 2.5rem;
+  margin: 0.75rem auto 0;
   border-radius: 999px;
+  border: 2px solid var(--foreground);
   color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 70%, transparent);
   cursor: pointer;
-  /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
-     is chosen to already clear the footer without overlapping it. */
-  z-index: 60;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 .scroll-hint:hover {
-  color: #06b6d4;
-}
-.scroll-hint::before {
-  content: "";
-  position: absolute;
-  inset: -0.5rem;
-  border-radius: 999px;
-  background: radial-gradient(
-    circle,
-    rgba(34, 211, 238, 0.6),
-    rgba(167, 139, 250, 0.4) 55%,
-    transparent 75%
-  );
-  filter: blur(6px);
-  z-index: -1;
-  animation: scroll-hint-glow 1.8s ease-in-out infinite;
-}
-@keyframes scroll-hint-glow {
-  0%,
-  100% {
-    opacity: 0.35;
-    scale: 0.85;
-  }
-  50% {
-    opacity: 0.9;
-    scale: 1.15;
-  }
+  background: var(--foreground);
+  color: var(--background);
 }
 @media (prefers-reduced-motion: reduce) {
-  .scroll-hint,
-  .scroll-hint::before {
-    animation: none;
+  .scroll-hint {
+    transition: none;
   }
 }

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -81,21 +81,26 @@ test.describe("homepage manifesto scroll effects", () => {
     await expect(page.locator(".manifesto-dot.active")).toHaveCount(1);
   });
 
-  test("scroll-hint arrow below the terminal advances one page on click (#544)", async ({
+  test("scroll-hint arrow advances one page on click, and is present on every page, not just the intro (#544, #554)", async ({
     page,
   }) => {
     await page.goto("/");
     await page.waitForTimeout(300);
     await page.mouse.click(200, 700);
 
-    const hint = page.getByRole("button", { name: "Scroll to the next page" });
-    await expect(hint).toBeVisible({ timeout: 2000 });
+    // One per page (intro + 4 ideas; not the CTA, which has its own
+    // action) — same aria-label on each, so every locator here is
+    // scoped to a specific instance rather than the ambiguous role query.
+    const hints = page.getByRole("button", { name: "Scroll to the next page" });
+    await expect(hints).toHaveCount(5);
 
     const dots = page.locator(".manifesto-dot");
     await expect(dots.first()).toHaveClass(/active/);
 
-    await hint.click();
-
+    await hints.first().click();
     await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
+
+    await hints.nth(1).click();
+    await expect(dots.nth(2)).toHaveClass(/active/, { timeout: 3000 });
   });
 });

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -64,12 +64,13 @@ test.describe("homepage manifesto scroll snap", () => {
     );
   });
 
-  // Footer is fixed site-wide, and unlike every other page here the slider
-  // fills the viewport edge to edge with no bottom padding of its own — a
-  // plain 100dvh page would render its last ~40px under the fixed footer
-  // (#541). Each page sizes off --page-h (globals.css), which reserves
-  // that space; this locks in a real clearance instead of just trusting
-  // the reserved amount matches the footer's actual rendered height.
+  // Header and Footer are both fixed, translucent overlays on every page
+  // here (min-h-dvh, same as everywhere else on the site) — each page's
+  // own pt-*/pb-* padding is what has to actually clear them, not the
+  // section's own box (which deliberately spans the full viewport, so
+  // checking *that* against the footer/header is always trivially near-
+  // zero regardless of whether real content is obscured — checked the
+  // wrong element early in #554 and it silently passed for that reason).
   //
   // 360px (Moto G4/Galaxy S/Pixel-class — Chrome DevTools' own small-phone
   // default) is the realistic floor, not 320px: that's specifically the
@@ -88,21 +89,28 @@ test.describe("homepage manifesto scroll snap", () => {
     { width: 1280, height: 720, label: "desktop (Playwright default)" },
     { width: 1280, height: 800, label: "desktop" },
   ]) {
-    test(`the intro page doesn't render under the fixed footer (${viewport.label})`, async ({
+    test(`intro content clears both the header and footer (${viewport.label})`, async ({
       page,
     }) => {
       await page.setViewportSize(viewport);
       await page.goto("/");
 
+      const headerBottom = await page
+        .locator("header")
+        .evaluate((el) => el.getBoundingClientRect().bottom);
+      const h1Top = await page
+        .locator("h1")
+        .evaluate((el) => el.getBoundingClientRect().top);
+      expect(h1Top - headerBottom).toBeGreaterThanOrEqual(0);
+
       const footerTop = await page
         .locator("footer")
         .evaluate((el) => el.getBoundingClientRect().top);
-      const introBottom = await page
-        .locator(".manifesto-slider section")
+      const hintBottom = await page
+        .locator(".scroll-hint")
         .first()
         .evaluate((el) => el.getBoundingClientRect().bottom);
-
-      expect(footerTop - introBottom).toBeGreaterThanOrEqual(0);
+      expect(footerTop - hintBottom).toBeGreaterThanOrEqual(0);
     });
   }
 


### PR DESCRIPTION
## Summary
Closes #554.

### 1. No more glow
Removed entirely per feedback ("i dont like the glowing"). Simple bordered circle now — `border-color` matches the arrow icon's own color (`--foreground`: black in light mode, white in dark).

### 2. Persistent, per-page button instead of a fixed intro-only overlay
Replaced the single fixed-position, intro-only button with a `NextPageHint` component rendered once per page (intro + each idea; not the CTA, which has its own "Launch /tools" action) in that page's own normal flow. It scrolls naturally with whichever page it's on instead of only existing on the intro and disappearing everywhere else.

### The redesign forced a real fix, not just a swap
Putting the button back in each page's flow reopened the footer/header clearance problem #541/#546/#548 kept finding — and this time measuring *both* edges (not just the footer) turned up a bug that had been there since #536 and every fix since: `--page-h` only ever reserved footer-height space, on the theory that `scroll-snap-align: center` only needed bottom clearance. **Wrong** — centering splits whatever headroom a shorter-than-`100dvh` page has evenly between top and bottom, so every page needed clearance from the header too (which is actually *taller* than the footer at every breakpoint) and never got it. That surfaced as pages overlapping the header, not just the footer — only once actually measured against both edges instead of just the one that had been checked before.

Replaced the whole `--page-h` / centered-shrunk-container model with what every other route on this site already does: each page is a genuine `min-h-dvh`, header/footer are fixed translucent overlays on top of it, and each page has its own `pt-*`/`pb-*` padding sized to clear them directly. Simpler to reason about, and the actual bug class (checking the section's own box instead of its content) can't recur the same way — there's no computed-height mismatch left to get wrong.

### Also found and fixed along the way
A genuinely nasty CSS bug: a code comment containing the literal substring `pt-*/pb-*` closed the enclosing `/* comment */` early (the parser sees `*/` as a token regardless of surrounding text), turning the rest of the intended comment into invalid CSS. The build "succeeded" with only an easy-to-miss warning, but the CSS optimizer silently **dropped `.scroll-hint` and everything after it** from the shipped output — caught by grepping the actual built CSS file, not just trusting that the build didn't error.

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build` (verified the CSS warning is gone and confirmed via `grep` on the built output that every custom class, not just `.scroll-hint`, actually made it into the shipped CSS)
- [x] `CI=true npx playwright test` — **167/167**
- [x] Rewrote the footer/header-clearance regression test to check actual content (`h1`, the button) instead of the section's own box — checking the box was silently meaningless under the new model (always near-zero regardless of real overlap), which is exactly how the header-clearance bug went undetected this long
- [x] Screenshots at 1280×720, a mid-scroll idea section, and mobile (375) confirming the border-only design, correct positioning scrolling with each page, and clearance from both header and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)