### PR TITLE
fix: scroll-hint button moves with the page instead of staying fixed

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -165,7 +165,7 @@ export default function ManifestoScroll() {
       >
         <section className="min-h-dvh snap-center" ref={register(0)}>
           <CirclesBackground variant="home" />
-          <TerminalIntro active={active[0]} />
+          <TerminalIntro />
         </section>
         <div className="manifesto-gradient">
           {ideas.map((idea, i) => (

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -150,7 +150,7 @@ function Hero() {
   );
 }
 
-export default function TerminalIntro({ active }: { active: boolean }) {
+export default function TerminalIntro() {
   const [frameIndex, setFrameIndex] = useState(0);
 
   // Render the completed terminal instantly on repeat visits within the
@@ -197,7 +197,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
     <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20">
       <Hero />
 
-      <div className="w-full max-w-3xl mb-6 sm:mb-8 md:mb-4 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
+      <div className="w-full max-w-3xl mb-4 sm:mb-5 md:mb-3 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
         <div className="flex items-center space-x-2 px-3 py-2 bg-[#2d2d2d] border-b border-neutral-700">
           <div className="w-3 h-3 rounded-full bg-red-500"></div>
           <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
@@ -241,19 +241,18 @@ export default function TerminalIntro({ active }: { active: boolean }) {
         </div>
       </div>
 
-      {/* Fixed to the viewport (not anchored below the terminal in normal
-          flow) so it costs nothing in the top/bottom padding budget every
-          page here has to fit its content within to clear the fixed
-          header/footer. Gated on `active` (this page is the one
-          currently in view) so it doesn't stay pinned on screen once
-          scrolled past the intro — intro-only was the ask (#556): once
-          used, it's implicitly clear scrolling continues to work the
-          same way on every other page. */}
+      {/* Sits in normal flow, right below the terminal, so it scrolls with
+          the intro's own content instead of staying pinned to the
+          viewport (feedback after #556: felt more natural moving with the
+          page than sitting fixed in place). It only exists on this one
+          page, so there's no separate "hide once scrolled past" state to
+          manage — scrolling to the next page carries it off-screen along
+          with everything else here, same as the terminal box above it. */}
       <button
         type="button"
         onClick={(e) => scrollToNextPage(e.currentTarget)}
         aria-label="Scroll to the next page"
-        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 ${active && isWaiting ? "fade-in-up" : "invisible"}`}
+        className={`scroll-hint ${isWaiting ? "fade-in-up" : "invisible"}`}
         style={fadeInStyle}
       >
         <svg

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -284,12 +284,14 @@ html {
   }
 }
 
-/* Scroll-hint chevron, fixed to the viewport and shown only on the intro
-   page (#556 — tried it on every page in #554, but once it's been used
-   once it's implicitly clear scrolling keeps working the same way on
-   every other page, so persistent everywhere wasn't wanted after all).
-   Both hints at and performs the page-by-page snap scroll on click — see
-   TerminalIntro.tsx.
+/* Scroll-hint chevron, shown only on the intro page (#556 — tried it on
+   every page in #554, but once it's been used once it's implicitly clear
+   scrolling keeps working the same way on every other page, so persistent
+   everywhere wasn't wanted after all). Sits in normal document flow below
+   the terminal (not fixed to the viewport, per feedback after #556 — it
+   should scroll away with the rest of the intro's content rather than
+   stay pinned in place). Both hints at and performs the page-by-page snap
+   scroll on click — see TerminalIntro.tsx.
 
    Filled, not transparent: reads as a solid button against the busy
    amber circles instead of a see-through outline. Both the fill
@@ -307,9 +309,6 @@ html {
   background: var(--background);
   color: var(--foreground);
   cursor: pointer;
-  /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
-     is chosen to already clear the footer without overlapping it. */
-  z-index: 60;
   transition:
     background 0.15s,
     color 0.15s;

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -81,7 +81,7 @@ test.describe("homepage manifesto scroll effects", () => {
     await expect(page.locator(".manifesto-dot.active")).toHaveCount(1);
   });
 
-  test("scroll-hint arrow is intro-only, fixed to the viewport, and advances one page on click (#544, #556)", async ({
+  test("scroll-hint arrow is intro-only, sits in normal flow, and advances one page on click (#544, #556, #558)", async ({
     page,
   }) => {
     await page.goto("/");
@@ -94,7 +94,11 @@ test.describe("homepage manifesto scroll effects", () => {
     const hint = page.getByRole("button", { name: "Scroll to the next page" });
     await expect(hint).toHaveCount(1);
     await expect(hint).toBeVisible();
-    await expect(hint).toHaveCSS("position", "fixed");
+    // In normal document flow (#558), not pinned to the viewport, so it
+    // scrolls away with the rest of the intro's content instead of
+    // needing its own separate hide/show state.
+    await expect(hint).toHaveCSS("position", "static");
+    await expect(hint).toBeInViewport();
 
     const dots = page.locator(".manifesto-dot");
     await expect(dots.first()).toHaveClass(/active/);
@@ -102,8 +106,7 @@ test.describe("homepage manifesto scroll effects", () => {
     await hint.click();
     await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
 
-    // No longer the active page, so the (still fixed, still the only
-    // instance) button is hidden rather than persisting into view.
-    await expect(hint).not.toBeVisible();
+    // Scrolled away along with the rest of the intro page it belongs to.
+    await expect(hint).not.toBeInViewport();
   });
 });


### PR DESCRIPTION
Closes #558.

## Summary
- Scroll-hint button is back in normal document flow below the terminal (not `position: fixed`), so it scrolls away with the rest of the intro content instead of sitting pinned to the viewport.
- Since it's no longer viewport-pinned across pages, the `active`-gated instant hide is gone — the existing opacity-only `fade-in-up` entrance is the only transition needed now, and there's no more hard "disappear" moment.
- Trimmed the terminal's own bottom margin slightly so the in-flow button still fits within the existing header/footer clearance budget at all tested viewports (360×740, 375×812, 1280×720, 1280×800).

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint` present in built CSS output)
- [x] Full Playwright suite (`--workers=1`): 167/167 passed