### PR TITLE
fix: scroll-hint button back to fixed bottom position, fades out instead of snapping

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -165,7 +165,7 @@ export default function ManifestoScroll() {
       >
         <section className="min-h-dvh snap-center" ref={register(0)}>
           <CirclesBackground variant="home" />
-          <TerminalIntro />
+          <TerminalIntro active={active[0]} />
         </section>
         <div className="manifesto-gradient">
           {ideas.map((idea, i) => (

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -150,7 +150,7 @@ function Hero() {
   );
 }
 
-export default function TerminalIntro() {
+export default function TerminalIntro({ active }: { active: boolean }) {
   const [frameIndex, setFrameIndex] = useState(0);
 
   // Render the completed terminal instantly on repeat visits within the
@@ -197,7 +197,7 @@ export default function TerminalIntro() {
     <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20">
       <Hero />
 
-      <div className="w-full max-w-3xl mb-4 sm:mb-5 md:mb-3 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
+      <div className="w-full max-w-3xl mb-6 sm:mb-8 md:mb-4 rounded-lg overflow-clip shadow-lg border border-neutral-800 bg-[#1a1a1a]">
         <div className="flex items-center space-x-2 px-3 py-2 bg-[#2d2d2d] border-b border-neutral-700">
           <div className="w-3 h-3 rounded-full bg-red-500"></div>
           <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
@@ -241,19 +241,27 @@ export default function TerminalIntro() {
         </div>
       </div>
 
-      {/* Sits in normal flow, right below the terminal, so it scrolls with
-          the intro's own content instead of staying pinned to the
-          viewport (feedback after #556: felt more natural moving with the
-          page than sitting fixed in place). It only exists on this one
-          page, so there's no separate "hide once scrolled past" state to
-          manage — scrolling to the next page carries it off-screen along
-          with everything else here, same as the terminal box above it. */}
+      {/* Fixed to the viewport, not anchored below the terminal in normal
+          flow, so it costs nothing in the top/bottom padding budget every
+          page here has to fit its content within to clear the fixed
+          header/footer — and so it stays put at the bottom of the screen
+          rather than wherever document flow happens to land it (#558's
+          in-flow version moved with the page, but lost the fixed bottom
+          position; asked back explicitly). Gated on `active` (this page
+          is the one currently in view) so it doesn't stay pinned on
+          screen once scrolled past the intro — intro-only was the ask
+          (#556). Hidden state uses .scroll-hint-hidden's opacity
+          transition rather than `invisible` (an instant visibility cut),
+          so leaving the intro fades the button out instead of just
+          snapping it away. */}
       <button
         type="button"
         onClick={(e) => scrollToNextPage(e.currentTarget)}
         aria-label="Scroll to the next page"
-        className={`scroll-hint ${isWaiting ? "fade-in-up" : "invisible"}`}
-        style={fadeInStyle}
+        aria-hidden={!(active && isWaiting)}
+        tabIndex={active && isWaiting ? 0 : -1}
+        data-testid="scroll-hint"
+        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 ${active && isWaiting ? "" : "scroll-hint-hidden"}`}
       >
         <svg
           width="26"

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -284,20 +284,25 @@ html {
   }
 }
 
-/* Scroll-hint chevron, shown only on the intro page (#556 — tried it on
-   every page in #554, but once it's been used once it's implicitly clear
-   scrolling keeps working the same way on every other page, so persistent
-   everywhere wasn't wanted after all). Sits in normal document flow below
-   the terminal (not fixed to the viewport, per feedback after #556 — it
-   should scroll away with the rest of the intro's content rather than
-   stay pinned in place). Both hints at and performs the page-by-page snap
-   scroll on click — see TerminalIntro.tsx.
+/* Scroll-hint chevron, fixed to the viewport and shown only on the intro
+   page (#556 — tried it on every page in #554, but once it's been used
+   once it's implicitly clear scrolling keeps working the same way on
+   every other page, so persistent everywhere wasn't wanted after all;
+   #558 tried moving it into normal document flow so it'd scroll away
+   with the page, but that traded away the fixed bottom position — asked
+   back explicitly, so it's fixed again). Both hints at and performs the
+   page-by-page snap scroll on click — see TerminalIntro.tsx.
 
    Filled, not transparent: reads as a solid button against the busy
    amber circles instead of a see-through outline. Both the fill
    (--background) and the border/icon (--foreground) are theme tokens, so
    it's a light disc with dark ink in light mode and the reverse in dark
-   mode, rather than a single hardcoded color pair. */
+   mode, rather than a single hardcoded color pair.
+
+   opacity lives in this same rule's transition (not a separate Tailwind
+   transition-opacity utility) so .scroll-hint-hidden's fade can't be
+   silently dropped by this rule's own `transition` shorthand overriding
+   a same-specificity utility class earlier in the cascade. */
 .scroll-hint {
   display: flex;
   align-items: center;
@@ -309,13 +314,22 @@ html {
   background: var(--background);
   color: var(--foreground);
   cursor: pointer;
+  opacity: 1;
+  /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
+     is chosen to already clear the footer without overlapping it. */
+  z-index: 60;
   transition:
+    opacity 0.3s ease-out,
     background 0.15s,
     color 0.15s;
 }
 .scroll-hint:hover {
   background: var(--foreground);
   color: var(--background);
+}
+.scroll-hint.scroll-hint-hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 @media (prefers-reduced-motion: reduce) {
   .scroll-hint {

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -81,7 +81,7 @@ test.describe("homepage manifesto scroll effects", () => {
     await expect(page.locator(".manifesto-dot.active")).toHaveCount(1);
   });
 
-  test("scroll-hint arrow is intro-only, sits in normal flow, and advances one page on click (#544, #556, #558)", async ({
+  test("scroll-hint arrow is intro-only, fixed to the viewport, and fades (not snaps) out on leaving the intro (#544, #556, #558)", async ({
     page,
   }) => {
     await page.goto("/");
@@ -94,11 +94,8 @@ test.describe("homepage manifesto scroll effects", () => {
     const hint = page.getByRole("button", { name: "Scroll to the next page" });
     await expect(hint).toHaveCount(1);
     await expect(hint).toBeVisible();
-    // In normal document flow (#558), not pinned to the viewport, so it
-    // scrolls away with the rest of the intro's content instead of
-    // needing its own separate hide/show state.
-    await expect(hint).toHaveCSS("position", "static");
-    await expect(hint).toBeInViewport();
+    await expect(hint).toHaveCSS("position", "fixed");
+    await expect(hint).toHaveCSS("opacity", "1");
 
     const dots = page.locator(".manifesto-dot");
     await expect(dots.first()).toHaveClass(/active/);
@@ -106,7 +103,12 @@ test.describe("homepage manifesto scroll effects", () => {
     await hint.click();
     await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
 
-    // Scrolled away along with the rest of the intro page it belongs to.
-    await expect(hint).not.toBeInViewport();
+    // No longer the active page: still fixed and still the only instance,
+    // but hidden via an opacity fade (#558) rather than an instant
+    // visibility cut. aria-hidden now correctly drops it out of the
+    // accessibility tree, so it has to be found by test id, not role.
+    const hiddenHint = page.getByTestId("scroll-hint");
+    await expect(hiddenHint).toHaveCSS("opacity", "0", { timeout: 2000 });
+    await expect(hiddenHint).toHaveAttribute("aria-hidden", "true");
   });
 });


### PR DESCRIPTION
Closes #560.

## Summary
- Reverts #558's in-flow positioning: fixed and in-flow are mutually exclusive (fixed = pinned to the viewport, never moves; in-flow = moves with the page, can't stay anchored to a screen edge) — fixed at the bottom is the preferred one.
- Keeps the good part of #558: hiding the button (once scrolled past the intro) now fades the opacity out via `.scroll-hint-hidden`, instead of the old instant `visibility: hidden` cut.
- The fade lives in `.scroll-hint`'s own `transition` rule (not a separate Tailwind `transition-opacity` utility), since a same-specificity utility class earlier in the cascade could otherwise have its `transition-property: opacity` silently dropped by `.scroll-hint`'s shorthand `transition` declaration.
- Hidden state also sets `aria-hidden`/`tabIndex={-1}` and `pointer-events: none`, since opacity alone (unlike the old `visibility: hidden`) doesn't remove an element from the accessibility tree or tab order.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint`/`.scroll-hint-hidden` present in built CSS output)
- [x] Full Playwright suite (`--workers=1`): 167/167 passed