### PR TITLE
fix: faster scroll-hint fade, match its colors to the Follow-on-GitHub pill

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -261,7 +261,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
         aria-hidden={!(active && isWaiting)}
         tabIndex={active && isWaiting ? 0 : -1}
         data-testid="scroll-hint"
-        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 ${active && isWaiting ? "" : "scroll-hint-hidden"}`}
+        className={`scroll-hint fixed bottom-14 sm:bottom-16 md:bottom-20 left-1/2 -translate-x-1/2 bg-black dark:bg-white text-white dark:text-black shadow-lg hover:bg-gray-900 dark:hover:bg-gray-100 ${active && isWaiting ? "" : "scroll-hint-hidden"}`}
       >
         <svg
           width="26"

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -294,10 +294,13 @@ html {
    page-by-page snap scroll on click — see TerminalIntro.tsx.
 
    Filled, not transparent: reads as a solid button against the busy
-   amber circles instead of a see-through outline. Both the fill
-   (--background) and the border/icon (--foreground) are theme tokens, so
-   it's a light disc with dark ink in light mode and the reverse in dark
-   mode, rather than a single hardcoded color pair.
+   amber circles instead of a see-through outline. Colors match the
+   Hero's "Follow on GitHub" pill (black/white, gray-900/gray-100 hover)
+   rather than the site's --background/--foreground tokens, so the two
+   fixed on-screen controls read as the same visual language — set via
+   Tailwind utility classes in TerminalIntro.tsx, not here, since this
+   rule's own `background`/`color` would otherwise silently override
+   same-specificity utility classes later.
 
    opacity lives in this same rule's transition (not a separate Tailwind
    transition-opacity utility) so .scroll-hint-hidden's fade can't be
@@ -310,22 +313,15 @@ html {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 999px;
-  border: 2px solid var(--foreground);
-  background: var(--background);
-  color: var(--foreground);
   cursor: pointer;
   opacity: 1;
   /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
      is chosen to already clear the footer without overlapping it. */
   z-index: 60;
   transition:
-    opacity 0.3s ease-out,
+    opacity 0.15s ease-out,
     background 0.15s,
     color 0.15s;
-}
-.scroll-hint:hover {
-  background: var(--foreground);
-  color: var(--background);
 }
 .scroll-hint.scroll-hint-hidden {
   opacity: 0;


### PR DESCRIPTION
Closes #562.

## Summary
- Opacity fade sped up from 0.3s to 0.15s.
- Scroll-hint button now uses the same black/white fill + gray-900/gray-100 hover palette as the Hero's "Follow on GitHub" pill (in both light and dark mode) instead of the --background/--foreground theme tokens it had before.
- Colors are set via Tailwind utility classes in the JSX rather than in the `.scroll-hint` CSS rule, since that rule's own `background`/`color` declarations would otherwise silently win the cascade over same-specificity utility classes (same class of bug called out in #560's PR description for `opacity`).

Verified manually with a throwaway Playwright script checking computed `background-color`/`color`/`box-shadow`/`transition-duration` in both `light` and `dark` `colorScheme` emulation — confirmed black-on-white / white-on-black with the 0.15s duration in both.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint` present in built CSS output)
- [x] Full Playwright suite (`--workers=1`): 167/167 passed