### PR TITLE
fix: rebalance homepage description toward usefulness over novelty

### DIFF
--- a/web-buddy/src/app/constants.ts
+++ b/web-buddy/src/app/constants.ts
@@ -4,6 +4,6 @@ export const SITE_NAME = "Creative Tools for Nerds";
 export const AUTHOR_NAME = "nobuddy";
 export const LEGAL_AUTHOR = "Matthias Eggert";
 export const SITE_DESCRIPTION =
-  "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps. Built for curious minds, developers, and digital explorers.";
+  "Explore nobuddy.org – genuinely useful tools, each built with a bit of personality. Built for curious minds, developers, and digital explorers.";
 export const TOOLS_DESCRIPTION =
   "A growing collection of useful web tools with unique personality and practical features for creative problem-solving, including procrastination, load testing and other things.";

--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -31,7 +31,7 @@ test.describe("homepage hero and manifesto content", () => {
 
     await expect(
       page.getByText(
-        "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps."
+        "Explore nobuddy.org – genuinely useful tools, each built with a bit of personality."
       )
     ).toBeVisible();
     // Hidden on mobile portrait to keep the intro compact (#541) — still


### PR DESCRIPTION
Closes #543.

## Summary
The tool catalog has grown beyond the original "fun/weird" tools (ProcrastinationBuddy, GameGalleryBuddy) into genuinely practical ones (ThrashBuddy's load testing, RideMergeBuddy's GPX merging, CollectionBuddy's cataloging), so the homepage subtitle leading with "playground... weird ideas" undersold half the catalog.

Presented four rewrite directions via AskUserQuestion (balanced dual / useful-first / minimal tweak / voice-forward); user picked **useful-first**:

- Before: "Explore nobuddy.org – a playground of creative tools, weird ideas & useful mini-apps. Built for curious minds, developers, and digital explorers."
- After: "Explore nobuddy.org – genuinely useful tools, each built with a bit of personality. Built for curious minds, developers, and digital explorers."

Confirmed the new text wraps to the same number of lines at every tested viewport (360×740 through 1280×800), so it doesn't disturb the intro's header/footer clearance budget (still 45px of slack at the tightest viewport, unchanged from before).

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 167/167 passed (updated one test asserting the old copy)