### PR TITLE
fix: update "hobby project" manifesto copy to acknowledge tools that matured

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -23,7 +23,7 @@ const ideas = [
   {
     emoji: "🚀",
     title: "This is a hobby project",
-    body: `No big team, no investors, no corporate goals. Just some developers shipping tools out of curiosity and frustration. Some ideas are polished, others are experimental. If something breaks or feels unfinished, it’s probably because it was released too early. That’s part of the fun. This space is intentionally imperfect. It's a sandbox for ideas that might not fit anywhere else. It’s about freedom, creativity, and the joy of building without pressure.`,
+    body: `Started as a handful of fun side projects – now some have grown into tools people actually rely on. No big team, no investors, no corporate goals, just developers building what they wish existed. Still no pressure, still no deadlines. Just less duct tape than it used to be.`,
   },
 ];
 


### PR DESCRIPTION
Closes #566.

## Summary
Follow-up to #543 — that issue's scope turned out to cover every scrollable page of the intro, not just the homepage subtitle. Reviewed all four manifesto idea pages + CTA; only "This is a hobby project" read oddly against tools that have grown past "experimental/unpolished" (ThrashBuddy's load testing, CollectionBuddy's catalog app, etc.) — it explicitly said "released too early... intentionally imperfect."

Presented four rewrite directions via AskUserQuestion (balanced acknowledgment / minimal tweak / growth story / keep as-is); user picked **growth story**:

- Before: "No big team, no investors, no corporate goals. Just some developers shipping tools out of curiosity and frustration. Some ideas are polished, others are experimental. If something breaks or feels unfinished, it's probably because it was released too early. That's part of the fun. This space is intentionally imperfect. It's a sandbox for ideas that might not fit anywhere else. It's about freedom, creativity, and the joy of building without pressure."
- After: "Started as a handful of fun side projects – now some have grown into tools people actually rely on. No big team, no investors, no corporate goals, just developers building what they wish existed. Still no pressure, still no deadlines. Just less duct tape than it used to be."

Also reviewed "Fueled by hype, grounded in curiosity" (its "not to optimize" line sits oddly next to a literal load-testing tool) — user chose to leave that one as is.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 167/167 passed