### PR TITLE
fix: blur the scroll-hint button when it becomes aria-hidden

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { SITE_NAME, GITHUB_URL, SITE_DESCRIPTION } from "../constants";
 import Link from "next/link";
@@ -182,6 +182,7 @@ function Hero() {
 
 export default function TerminalIntro({ active }: { active: boolean }) {
   const [frameIndex, setFrameIndex] = useState(0);
+  const scrollHintRef = useRef<HTMLButtonElement>(null);
 
   // Render the completed terminal instantly on repeat visits within the
   // same session instead of replaying the ~4s typing animation every time.
@@ -222,6 +223,15 @@ export default function TerminalIntro({ active }: { active: boolean }) {
 
   const { lines } = frames[frameIndex];
   const isWaiting = frameIndex === lastFrame;
+
+  // aria-hidden/tabIndex below make the button unreachable the instant
+  // active && isWaiting flips false, but that alone doesn't move focus off
+  // it — a keyboard user who just activated it (scrolling away, which is
+  // what flips it false) would otherwise be left with DOM focus stranded
+  // on a now aria-hidden, unfocusable element.
+  useEffect(() => {
+    if (!(active && isWaiting)) scrollHintRef.current?.blur();
+  }, [active, isWaiting]);
 
   return (
     <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-24 pb-14 sm:pb-16 md:pb-20">
@@ -286,6 +296,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
           so leaving the intro fades the button out instead of just
           snapping it away. */}
       <button
+        ref={scrollHintRef}
         type="button"
         onClick={(e) => scrollToNextPage(e.currentTarget)}
         aria-label="Scroll to the next page"

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -111,4 +111,27 @@ test.describe("homepage manifesto scroll effects", () => {
     await expect(hiddenHint).toHaveCSS("opacity", "0", { timeout: 2000 });
     await expect(hiddenHint).toHaveAttribute("aria-hidden", "true");
   });
+
+  test("scroll-hint button doesn't strand keyboard focus once it's used (#572)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForTimeout(300);
+    await page.mouse.click(200, 700);
+
+    const hint = page.getByRole("button", { name: "Scroll to the next page" });
+    await hint.focus();
+    await expect(hint).toBeFocused();
+
+    await page.keyboard.press("Enter");
+
+    const dots = page.locator(".manifesto-dot");
+    await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
+
+    // The button is now aria-hidden/tabIndex=-1; DOM focus must have moved
+    // off it rather than being left stranded on a now-inaccessible element.
+    const hiddenHint = page.getByTestId("scroll-hint");
+    await expect(hiddenHint).toHaveAttribute("aria-hidden", "true");
+    await expect(hiddenHint).not.toBeFocused();
+  });
 });


### PR DESCRIPTION
Closes #572.

## Summary
The scroll-hint button's `aria-hidden`/`tabIndex` flip to hidden/-1 the instant the intro scrolls out of view, but nothing ever moved DOM focus off it. A keyboard user who Tabs to the button and activates it (scrolling away, which is what triggers the hide) could be left with browser focus stranded on a now `aria-hidden="true"`, `tabIndex="-1"` element — inconsistent Tab/Shift+Tab behavior across browsers and no screen-reader announcement of where focus went.

Fix: a `useEffect` keyed on the same `active && isWaiting` condition calls `.blur()` on the button via a ref whenever it transitions to hidden.

## Verification
Added a keyboard-driven Playwright test (`hint.focus()` + `page.keyboard.press("Enter")`, then asserts the now-`aria-hidden` button `not.toBeFocused()`). Confirmed it actually catches the regression: temporarily neutered the blur call and reran — the test failed with `Received: focused` on the aria-hidden button; restored the fix and it passes.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] New keyboard-focus test confirmed to fail pre-fix, pass post-fix
- [x] Full Playwright suite (`--workers=1`): 168/168 passed