### PR TITLE
test: guard boundingBox() with a visibility check

### DIFF
--- a/web-buddy/tests/terminal-skip.spec.ts
+++ b/web-buddy/tests/terminal-skip.spec.ts
@@ -60,6 +60,9 @@ test.describe("terminal intro skip and session persistence", () => {
 
     const box = page.locator(".font-mono").locator("..");
     await page.waitForTimeout(100); // first paint, before any line appears
+    // boundingBox() returns null for an unrendered element; guard against
+    // that instead of risking a raw TypeError on a slow/flaky first paint.
+    await expect(box).toBeVisible();
     const initialHeight = (await box.boundingBox())!.height;
 
     await expect(


### PR DESCRIPTION
Closes #573.

## Summary
`(await box.boundingBox())!.height` at the first (unguarded) call site assumed `boundingBox()` never returns `null` — but Playwright's own docs say it does for an unrendered element. Added `await expect(box).toBeVisible();` right before it, so a slow/flaky first paint in CI fails with a readable assertion message instead of a raw `TypeError: Cannot read properties of null`.

(The second `boundingBox()!` call in the same test was already effectively guarded by a preceding `toBeVisible()` on a descendant — left as is.)

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 168/168 passed