### PR TITLE
refactor: extract shared prefersReducedMotion() helper

### DIFF
--- a/web-buddy/src/app/components/AnimatedClip.tsx
+++ b/web-buddy/src/app/components/AnimatedClip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { prefersReducedMotion } from "../utils";
 
 interface AnimatedClipProps {
   src: string;
@@ -27,7 +28,7 @@ export default function AnimatedClip({
     const video = videoRef.current;
     if (!video) return;
 
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    if (prefersReducedMotion()) {
       return;
     }
 

--- a/web-buddy/src/app/components/EmojiBackground.tsx
+++ b/web-buddy/src/app/components/EmojiBackground.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { prefersReducedMotion } from "../utils";
 
 type Particle = {
   baseX: number;
@@ -88,9 +89,7 @@ export default function EmojiGridCanvas() {
       ensureGrid(width, height);
     };
 
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    ).matches;
+    const reduceMotion = prefersReducedMotion();
 
     const render = (animate: boolean) => {
       resizeCanvasIfNeeded();
@@ -122,8 +121,8 @@ export default function EmojiGridCanvas() {
     // Always redraws immediately on resize (rather than only recomputing
     // the grid and waiting for the next animation frame), since resize is
     // rare enough that one extra draw call is free.
-    const handleResize = () => render(!prefersReducedMotion);
-    if (prefersReducedMotion) {
+    const handleResize = () => render(!reduceMotion);
+    if (reduceMotion) {
       render(false);
     } else {
       rafRef.current = requestAnimationFrame(draw);

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { SITE_NAME, GITHUB_URL, SITE_DESCRIPTION } from "../constants";
+import { prefersReducedMotion } from "../utils";
 import Link from "next/link";
 
 const SESSION_KEY = "terminalIntroPlayed";
@@ -126,12 +127,9 @@ const sizerLines: ScriptLine[] = [
 function scrollToNextPage(button: HTMLElement) {
   const slider = button.closest<HTMLElement>(".manifesto-slider");
   if (!slider) return;
-  const reduceMotion = window.matchMedia(
-    "(prefers-reduced-motion: reduce)"
-  ).matches;
   slider.scrollBy({
     top: slider.clientHeight,
-    behavior: reduceMotion ? "auto" : "smooth",
+    behavior: prefersReducedMotion() ? "auto" : "smooth",
   });
 }
 

--- a/web-buddy/src/app/utils.ts
+++ b/web-buddy/src/app/utils.ts
@@ -1,0 +1,6 @@
+// Client-only: window isn't defined during SSR. Every call site already
+// only calls this from an event handler or inside a useEffect, both of
+// which run client-side only.
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}


### PR DESCRIPTION
Closes #574.

## Summary
`window.matchMedia("(prefers-reduced-motion: reduce)").matches` was inlined independently in three places: `TerminalIntro.tsx`'s `scrollToNextPage`, `AnimatedClip.tsx`'s mount effect, and `EmojiBackground.tsx`'s mount effect.

Extracted a plain `prefersReducedMotion()` function into a new `src/app/utils.ts` and used it at all three call sites. Deliberately a plain function, not a React hook: none of the three call sites need to react to the media query changing live (they each check once, either at effect setup or at click time), and `scrollToNextPage` isn't even a component/hook context — it's a plain function called from an `onClick` handler, so a hook wouldn't be callable there under the rules of hooks.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 168/168 passed