### PR TITLE
test: factor the terminal-output locator into a shared helper

### DIFF
--- a/web-buddy/tests/homepage.spec.ts
+++ b/web-buddy/tests/homepage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { terminalOutputText } from "./utils/terminal";
 
 test.describe("homepage hero and manifesto content", () => {
   test("renders the terminal intro hero", async ({ page }) => {
@@ -13,13 +14,8 @@ test.describe("homepage hero and manifesto content", () => {
   test("terminal intro plays the script lines", async ({ page }) => {
     await page.goto("/");
 
-    // An invisible same-content sizer also contains this text (keeps the
-    // terminal box's height constant throughout the animation — see
-    // TerminalIntro.tsx), so this scopes through the visible output.
     await expect(
-      page
-        .getByTestId("terminal-output")
-        .getByText("You’ve reached The Buddy Compendium.")
+      terminalOutputText(page, "You’ve reached The Buddy Compendium.")
     ).toBeVisible({ timeout: 15000 });
   });
 

--- a/web-buddy/tests/reduced-motion.spec.ts
+++ b/web-buddy/tests/reduced-motion.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { terminalOutputText } from "./utils/terminal";
 
 test.describe("prefers-reduced-motion", () => {
   test("emoji background canvas is static", async ({ page }) => {
@@ -25,12 +26,7 @@ test.describe("prefers-reduced-motion", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/");
 
-    // An invisible same-content sizer also contains this text (keeps the
-    // terminal box's height constant throughout the animation — see
-    // TerminalIntro.tsx), so this scopes through the visible output.
-    const pulse = page
-      .getByTestId("terminal-output")
-      .getByText("Scroll down to continue...");
+    const pulse = terminalOutputText(page, "Scroll down to continue...");
     await expect(pulse).toBeVisible({ timeout: 15000 });
     await expect(pulse).toHaveCSS("animation-name", "none");
   });

--- a/web-buddy/tests/terminal-skip.spec.ts
+++ b/web-buddy/tests/terminal-skip.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from "@playwright/test";
+import { terminalOutput, terminalOutputText } from "./utils/terminal";
 
-// "Scroll down to continue..." and the full transcript text also exist in
-// an invisible same-content sizer (see TerminalIntro.tsx) that keeps the
-// box's height constant throughout the animation, so text queries here
-// scope through the visible output's data-testid rather than matching
-// both copies.
 test.describe("terminal intro skip and session persistence", () => {
   test("a click fast-forwards the terminal instead of forcing the full ~5s animation", async ({
     page,
@@ -17,7 +13,7 @@ test.describe("terminal intro skip and session persistence", () => {
     await page.mouse.click(10, 10);
 
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 1000 });
   });
 
@@ -28,7 +24,7 @@ test.describe("terminal intro skip and session persistence", () => {
     await page.keyboard.press("Space");
 
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 1000 });
   });
 
@@ -39,7 +35,7 @@ test.describe("terminal intro skip and session persistence", () => {
     await page.waitForTimeout(200);
     await page.mouse.click(10, 10);
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 1000 });
 
     await page.goto("/tools");
@@ -48,7 +44,7 @@ test.describe("terminal intro skip and session persistence", () => {
     // On the repeat visit the completed terminal renders immediately,
     // without waiting for the typing animation to play out again.
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 500 });
   });
 
@@ -66,7 +62,7 @@ test.describe("terminal intro skip and session persistence", () => {
     const initialHeight = (await box.boundingBox())!.height;
 
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 10000 });
     const finalHeight = (await box.boundingBox())!.height;
 
@@ -81,12 +77,12 @@ test.describe("terminal intro skip and session persistence", () => {
     await page.waitForTimeout(200);
     await page.mouse.click(10, 10);
     await expect(
-      page.getByTestId("terminal-output").getByText("Scroll down to continue...")
+      terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 1000 });
 
-    const overflow = await page
-      .getByTestId("terminal-output")
-      .evaluate((el) => el.scrollWidth - el.clientWidth);
+    const overflow = await terminalOutput(page).evaluate(
+      (el) => el.scrollWidth - el.clientWidth
+    );
     expect(overflow).toBe(0);
   });
 });

--- a/web-buddy/tests/utils/terminal.ts
+++ b/web-buddy/tests/utils/terminal.ts
@@ -1,0 +1,13 @@
+import type { Page } from "@playwright/test";
+
+// The terminal's real (visible) output — scoped through this testid since
+// an invisible same-content sizer also contains the same text (keeps the
+// terminal box's height constant throughout the animation — see
+// TerminalIntro.tsx), and an unscoped text query would match both copies.
+export function terminalOutput(page: Page) {
+  return page.getByTestId("terminal-output");
+}
+
+export function terminalOutputText(page: Page, text: string) {
+  return terminalOutput(page).getByText(text);
+}


### PR DESCRIPTION
Closes #575.

## Summary
`page.getByTestId("terminal-output").getByText(...)` was copy-pasted verbatim 8 times across `terminal-skip.spec.ts` (6x), `homepage.spec.ts` (1x), and `reduced-motion.spec.ts` (1x), each carrying the same explanatory comment about the invisible ghost-sizer duplicate it's scoping around.

Added `tests/utils/terminal.ts` with `terminalOutput(page)` and `terminalOutputText(page, text)`, following the same shared-test-utility pattern `tests/utils/contrast.ts` already established (used by 4 other spec files). Also covers the one plain (non-`.getByText`) usage in `terminal-skip.spec.ts`'s overflow test.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 168/168 passed