### PR TITLE
docs: dedupe the scroll-hint fixed-vs-in-flow history into one comment

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -284,16 +284,11 @@ export default function TerminalIntro({ active }: { active: boolean }) {
       {/* Fixed to the viewport, not anchored below the terminal in normal
           flow, so it costs nothing in the top/bottom padding budget every
           page here has to fit its content within to clear the fixed
-          header/footer — and so it stays put at the bottom of the screen
-          rather than wherever document flow happens to land it (#558's
-          in-flow version moved with the page, but lost the fixed bottom
-          position; asked back explicitly). Gated on `active` (this page
-          is the one currently in view) so it doesn't stay pinned on
-          screen once scrolled past the intro — intro-only was the ask
-          (#556). Hidden state uses .scroll-hint-hidden's opacity
-          transition rather than `invisible` (an instant visibility cut),
-          so leaving the intro fades the button out instead of just
-          snapping it away. */}
+          header/footer. Gated on `active` (this page is the one currently
+          in view) so it doesn't stay pinned on screen once scrolled past
+          the intro — intro-only was the ask (#556). See globals.css's
+          .scroll-hint rule for why it's fixed rather than in-flow (#556,
+          #558) and why it fades out rather than snapping away (#560). */}
       <button
         ref={scrollHintRef}
         type="button"

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -293,6 +293,10 @@ html {
    back explicitly, so it's fixed again). Both hints at and performs the
    page-by-page snap scroll on click — see TerminalIntro.tsx.
 
+   .scroll-hint-hidden (#560) fades the button out via opacity rather than
+   an instant visibility cut, so leaving the intro fades it away instead
+   of snapping it out of view.
+
    Filled, not transparent: reads as a solid button against the busy
    amber circles instead of a see-through outline. Colors match the
    Hero's "Follow on GitHub" pill (black/white, gray-900/gray-100 hover)


### PR DESCRIPTION
Closes #577.

## Summary
The "why fixed, not in-flow" design history (#556/#558) was narrated near-verbatim in two places — `globals.css`'s `.scroll-hint` rule and `TerminalIntro.tsx` near the button — with different wording each time, risking the two drifting apart on the next redesign (there have already been several: #544, #554, #556, #558, #560, #562).

`globals.css` is now the canonical explanation (also folds in the #560 fade-vs-instant-cut rationale, which wasn't there before). `TerminalIntro.tsx`'s comment keeps only its own component-specific facts (padding-budget-free positioning, `active` gating) and points at `globals.css` for the rest.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint` present in built CSS, and `/*`/`*/` counts balanced)
- [x] Full Playwright suite (`--workers=1`): 168/168 passed