### PR TITLE
cleanup: drop redundant md:pt-20 no-op in ManifestoSection/CallToActionSection

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -94,7 +94,7 @@ function ManifestoSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-6 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-6 pt-16 sm:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-emoji text-6xl mb-6">{emoji}</div>
       <h2 className="text-2xl sm:text-3xl font-bold mb-4">{title}</h2>
@@ -115,7 +115,7 @@ function CallToActionSection({
   return (
     <section
       ref={register}
-      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-10 pt-16 sm:pt-20 md:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
+      className={`manifesto-section min-h-dvh snap-center flex flex-col justify-center items-center text-center px-10 pt-16 sm:pt-20 pb-14 sm:pb-16 md:pb-20 ${revealed ? "in-view" : ""}`}
     >
       <div className="manifesto-cta-text text-xl sm:text-2xl mb-6">
         Explore the tools. Adopt a Buddy.


### PR DESCRIPTION
Closes #578.

## Summary
Both `ManifestoSection` and `CallToActionSection` set `sm:pt-20 md:pt-20` — since Tailwind v4's default breakpoints are mobile-first/min-width with no overriding `@theme` in this repo, `sm:pt-20` already applies at `md:` and up. `md:pt-20` was a byte-identical no-op that could mislead a future reader into thinking there's an intentional per-breakpoint distinction here (unlike `TerminalIntro.tsx`'s genuinely different `md:pt-24`, see #582).

## Verification
Measured the computed `padding-top` of `.manifesto-section` at a 1280px viewport before and after: unchanged at `80px`.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Computed-style check confirming zero visual change
- [x] Full Playwright suite (`--workers=1`): 168/168 passed