### PR TITLE
perf: hoist the ghost sizer's rendered JSX to a module-level constant

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -147,6 +147,15 @@ function LineText({ line }: { line: ScriptLine }) {
   );
 }
 
+// sizerLines never changes after module load, so this is built once here
+// rather than being re-mapped on every one of the ~18 frameIndex state
+// updates TerminalIntro goes through during the typing animation.
+const sizerContent = sizerLines.map((line, i) => (
+  <div key={i} className="whitespace-pre-wrap break-words">
+    <LineText line={line} />
+  </div>
+));
+
 function Hero() {
   return (
     <section
@@ -252,11 +261,7 @@ export default function TerminalIntro({ active }: { active: boolean }) {
             final line. */}
         <div className="grid py-5 sm:py-8 md:py-4 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           <div aria-hidden="true" className="invisible [grid-area:1/1]">
-            {sizerLines.map((line, i) => (
-              <div key={i} className="whitespace-pre-wrap break-words">
-                <LineText line={line} />
-              </div>
-            ))}
+            {sizerContent}
             <div className="mt-8">Scroll down to continue...</div>
           </div>
 


### PR DESCRIPTION
Closes #579.

## Summary
`sizerLines` (the ghost sizer's data) never changes after module load, but its `.map()` was re-run inline in the render return on every one of the ~18 `frameIndex` state updates during the typing animation. Built once as `sizerContent` alongside `sizerLines` (right after `LineText`, since it needs that component) and referenced directly in JSX instead.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `terminal-skip.spec.ts` (height-consistency test) passes
- [x] Full Playwright suite (`--workers=1`): 168/168 passed