### PR TITLE
perf: wrap TerminalIntro in React.memo

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { SITE_NAME, GITHUB_URL, SITE_DESCRIPTION } from "../constants";
 import { prefersReducedMotion } from "../utils";
@@ -187,7 +187,7 @@ function Hero() {
   );
 }
 
-export default function TerminalIntro({ active }: { active: boolean }) {
+function TerminalIntro({ active }: { active: boolean }) {
   const [frameIndex, setFrameIndex] = useState(0);
   const scrollHintRef = useRef<HTMLButtonElement>(null);
 
@@ -321,3 +321,11 @@ export default function TerminalIntro({ active }: { active: boolean }) {
     </div>
   );
 }
+
+// TerminalIntro never unmounts (it's the first section inside the
+// always-mounted .manifesto-slider), and its parent re-renders on every
+// IntersectionObserver update for any of the 6 manifesto sections, not
+// just this one — memo avoids redoing this component's own work
+// (including reconciling the ghost sizer) when its own `active` prop
+// hasn't actually changed.
+export default memo(TerminalIntro);


### PR DESCRIPTION
Closes #580.

## Summary
`TerminalIntro` never unmounts — it's the first section inside the always-mounted `.manifesto-slider`. Its parent (`ManifestoScroll`) re-renders on every `IntersectionObserver` callback for any of the 6 manifesto sections crossing the 0.55 threshold, not just the intro's own. Without a memo boundary, React re-invoked `TerminalIntro`'s full function body (including reconciling the ghost sizer) on every such scroll transition even when its own `active` prop hadn't changed. Wrapped the default export with `React.memo`.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 168/168 passed