### PR TITLE
perf: resolve each observer entry's index once, shared by both state updates

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -47,21 +47,29 @@ function useManifesto() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
+        // Each entry's section index is resolved once here, shared by
+        // both updates below, instead of setActive and setRevealed each
+        // independently re-scanning refs.current for the same entries.
+        const changes = entries
+          .map((entry) => ({
+            index: refs.current.indexOf(entry.target as HTMLElement),
+            isIntersecting: entry.isIntersecting,
+          }))
+          .filter((change) => change.index !== -1);
+
         setActive((prev) => {
           const next = [...prev];
-          for (const entry of entries) {
-            const i = refs.current.indexOf(entry.target as HTMLElement);
-            if (i !== -1) next[i] = entry.isIntersecting;
+          for (const { index, isIntersecting } of changes) {
+            next[index] = isIntersecting;
           }
           return next;
         });
         setRevealed((prev) => {
           let changed = false;
           const next = [...prev];
-          for (const entry of entries) {
-            const i = refs.current.indexOf(entry.target as HTMLElement);
-            if (i !== -1 && entry.isIntersecting && !next[i]) {
-              next[i] = true;
+          for (const { index, isIntersecting } of changes) {
+            if (isIntersecting && !next[index]) {
+              next[index] = true;
               changed = true;
             }
           }


### PR DESCRIPTION
Closes #581.

## Summary
The `IntersectionObserver` callback in `useManifesto()` ran `setActive` and `setRevealed` as two separate state updates, each independently looping over the same `entries` and independently calling `refs.current.indexOf(entry.target)` per entry — duplicating the same lookup twice per callback firing.

Now resolved once into a shared `changes` array (`{ index, isIntersecting }` per entry, filtered to known sections), consumed by both updaters.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `manifesto-scroll-effects.spec.ts` + `scroll-snap.spec.ts` (dot highlighting, reveal animation) pass
- [x] Full Playwright suite (`--workers=1`): 168/168 passed