### PR TITLE
docs: note that the intro's md:pt-24 is intentionally looser than other sections

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -242,6 +242,9 @@ function TerminalIntro({ active }: { active: boolean }) {
   }, [showHint]);
 
   return (
+    // md:pt-24 is intentionally looser than ManifestoSection/
+    // CallToActionSection's md:pt-20 (#552 — desktop felt dense here) —
+    // not a leftover inconsistency to "fix" back to md:pt-20.
     <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-24 pb-14 sm:pb-16 md:pb-20">
       <Hero />
 


### PR DESCRIPTION
Closes #582.

## Summary
`TerminalIntro.tsx`'s wrapper uses `md:pt-24` while `ManifestoScroll.tsx`'s `ManifestoSection`/`CallToActionSection` use `md:pt-20`. Both paddings exist to clear the same fixed Header, and both files are otherwise densely commented about spacing decisions, making the silent 4-unit difference conspicuous rather than self-evident. PR #552 confirms this was an intentional, approved change ("Desktop felt dense... Bumped wrapper top padding... at md only"), but nothing in the code said so — a future contributor reading only the JSX could plausibly "fix" the inconsistency by reverting it. Added a one-line comment.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Full Playwright suite (`--workers=1`): 168/168 passed