### PR TITLE
fix: enforce scroll-hint's Tailwind precedence structurally via @layer components

### DIFF
--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -302,37 +302,47 @@ html {
    Hero's "Follow on GitHub" pill (black/white, gray-900/gray-100 hover)
    rather than the site's --background/--foreground tokens, so the two
    fixed on-screen controls read as the same visual language — set via
-   Tailwind utility classes in TerminalIntro.tsx, not here, since this
-   rule's own `background`/`color` would otherwise silently override
-   same-specificity utility classes later.
+   Tailwind utility classes in TerminalIntro.tsx, not here.
 
    opacity lives in this same rule's transition (not a separate Tailwind
    transition-opacity utility) so .scroll-hint-hidden's fade can't be
-   silently dropped by this rule's own `transition` shorthand overriding
-   a same-specificity utility class earlier in the cascade. */
-.scroll-hint {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 999px;
-  cursor: pointer;
-  opacity: 1;
-  /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
-     is chosen to already clear the footer without overlapping it. */
-  z-index: 60;
-  transition:
-    opacity 0.15s ease-out,
-    background 0.15s,
-    color 0.15s;
-}
-.scroll-hint.scroll-hint-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-@media (prefers-reduced-motion: reduce) {
+   silently dropped by a same-specificity utility class overriding this
+   rule's own `transition` shorthand.
+
+   @layer components (not an unlayered rule) so this rule structurally
+   can't win a cascade fight against the Tailwind utility classes above —
+   @import "tailwindcss" declares `@layer theme, base, components,
+   utilities`, and later-declared layers always beat earlier ones
+   regardless of specificity or source order. Without this, adding so
+   much as a `background` or `border-color` here later would silently
+   and permanently override the button's Tailwind-driven dark-mode
+   colors, the same class of bug this rule already had to work around
+   once (#562). */
+@layer components {
   .scroll-hint {
-    transition: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    cursor: pointer;
+    opacity: 1;
+    /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
+       is chosen to already clear the footer without overlapping it. */
+    z-index: 60;
+    transition:
+      opacity 0.15s ease-out,
+      background 0.15s,
+      color 0.15s;
+  }
+  .scroll-hint.scroll-hint-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-hint {
+      transition: none;
+    }
   }
 }


### PR DESCRIPTION
Closes #583.

## Summary
`.scroll-hint` previously avoided declaring `background`/`color`/`border-color` purely by convention (documented in a comment) to dodge this unlayered CSS rule always beating Tailwind's `@layer utilities` classes in the cascade regardless of specificity or source order. That's correct today, but fragile: nothing stopped a future contributor from adding an unrelated `background` or `border-color` declaration to this same rule, silently and permanently overriding the button's Tailwind-driven dark-mode colors again — exactly the class of bug this rule already had to work around once (#562).

Moved the whole rule into `@layer components`. Tailwind's own layer order (`@layer theme, base, components, utilities`, from `@import "tailwindcss"`) always has `utilities` beat `components`, so the precedence is now structural rather than convention-only — the rule could add `background`/`color` today and Tailwind's utility classes would still win.

## Verification
Same technique as #562/#563: a throwaway Playwright script checking computed `background-color`/`color`/`opacity` in both `light` and `dark` `colorScheme` emulation, after the `@layer` change.
- Light: `bg: rgb(0, 0, 0)`, `color: rgb(255, 255, 255)`, `opacity: 1`
- Dark: `bg: rgb(255, 255, 255)`, `color: rgb(0, 0, 0)`, `opacity: 1`

Unchanged from before the change, confirming `@layer components` doesn't disturb the intended precedence.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint` present in built CSS, `/*`/`*/` and brace counts balanced)
- [x] Computed-style check in both light/dark mode (see above)
- [x] Full Playwright suite (`--workers=1`): 168/168 passed

---

This is the last of the 13 issues (#571-#583) filed from the `/code-review ultra` (local max-effort fallback) run on the scroll-hint/intro feature branch.