### PR TITLE
chore: trim comment bloat in the intro/manifesto feature

### DIFF
--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -29,12 +29,8 @@ const ideas = [
 
 const sectionCount = ideas.length + 2; // + intro + call-to-action
 
-// One shared observer drives both the reveal animation and the dot rail —
-// `active` tracks whichever section is currently centered (for the dots),
-// while `revealed` latches true the first time a section appears and never
-// clears, so already-seen content stays revealed on scroll-away. Sections
-// receive a `register` callback rather than the ref array itself, so they
-// never mutate a value owned by the parent hook directly.
+// One observer drives both: `active` tracks the centered section (dots),
+// `revealed` latches true once and stays true (reveal animation).
 function useManifesto() {
   const refs = useRef<(HTMLElement | null)[]>([]);
   const [active, setActive] = useState<boolean[]>(() =>
@@ -47,9 +43,7 @@ function useManifesto() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        // Each entry's section index is resolved once here, shared by
-        // both updates below, instead of setActive and setRevealed each
-        // independently re-scanning refs.current for the same entries.
+        // Resolved once, shared by both updates below.
         const changes = entries
           .map((entry) => ({
             index: refs.current.indexOf(entry.target as HTMLElement),
@@ -139,9 +133,7 @@ function CallToActionSection({
   );
 }
 
-// Purely a visual scroll-position affordance — the section headings already
-// convey where you are, so this stays out of the accessibility tree rather
-// than adding redundant, constantly-changing announcements.
+// Decorative only — headings already convey scroll position.
 function ScrollDots({ active }: { active: boolean[] }) {
   const activeIndex = active.lastIndexOf(true);
   return (
@@ -161,11 +153,8 @@ export default function ManifestoScroll() {
 
   return (
     <>
-      {/* Its own overflow-y scroll container (not the document) is what
-          makes native scroll-snap actually reliable — see globals.css for
-          why. tabIndex + aria-label keep it keyboard-reachable, since a
-          nested scroll container isn't otherwise focusable and none of the
-          idea sections contain a focusable element of their own (#413). */}
+      {/* tabIndex + aria-label: nested scroll containers aren't otherwise
+          keyboard-focusable. */}
       <div
         className="manifesto-slider"
         tabIndex={0}

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -55,27 +55,17 @@ const moreLoadingMessages = [
 const shuffled = [...moreLoadingMessages].sort(() => 0.5 - Math.random());
 const [loadingMessage, msg1, msg2] = shuffled.slice(0, 3);
 
-// The longest message in the list, picked deterministically (no
-// Math.random) — used only for the ghost sizer below, which must render
-// identical text on the server and the client. Reusing the randomly
-// shuffled msg1/msg2/loadingMessage there would pick a different message
-// in each environment under static export (the server's shuffle runs once
-// at build time; the client re-evaluates the module fresh at hydration),
-// producing a real text mismatch on first paint even though the node is
-// invisible. Picking the single longest message for every slot also keeps
-// the sizer's height a safe upper bound, since no real random pick can be
-// taller than it.
+// Deterministic (no Math.random), unlike msg1/msg2/loadingMessage, so the
+// ghost sizer below renders the same text on the server and the client —
+// also a safe upper bound for its height.
 const maxWidthPlaceholder = moreLoadingMessages.reduce((longest, msg) =>
   msg.length > longest.length ? msg : longest
 );
 
 type Frame = { lines: ScriptLine[]; delay: number };
 
-// Each frame is a full snapshot of the terminal's lines plus how long to
-// wait before showing it — flattening the whole "type a line, tick the
-// loading bar, pause, type the next line" choreography into one linear
-// list turns the old phase/lineIndex/loadingIndex state machine (four
-// separate effects) into a single "advance to the next frame" effect.
+// Each frame is a full snapshot of the terminal's lines plus a delay,
+// so playback is a single "advance to the next frame" effect.
 function buildFrames(): Frame[] {
   const frames: Frame[] = [{ lines: [], delay: 0 }];
   const last = () => frames[frames.length - 1].lines;
@@ -105,10 +95,8 @@ function buildFrames(): Frame[] {
 const frames = buildFrames();
 const lastFrame = frames.length - 1;
 
-// Same shape as frames[lastFrame].lines, but with maxWidthPlaceholder in
-// place of the randomly-picked msg1/loadingMessage/msg2 slots — see the
-// comment on maxWidthPlaceholder above for why the ghost sizer can't just
-// reuse frames[lastFrame].lines directly.
+// Same shape as frames[lastFrame].lines, with maxWidthPlaceholder instead
+// of the random text.
 const sizerLines: ScriptLine[] = [
   { role: "cmd", text: "initialize --buddyverse" },
   { role: "echo", text: maxWidthPlaceholder },
@@ -121,9 +109,6 @@ const sizerLines: ScriptLine[] = [
   { role: "output", text: "↳ You’ve reached The Buddy Compendium." },
 ];
 
-// Both hints at and performs the page-by-page snap scroll, so the
-// paging behavior itself is discoverable (#544) rather than something a
-// visitor has to stumble into via a wheel gesture.
 function scrollToNextPage(button: HTMLElement) {
   const slider = button.closest<HTMLElement>(".manifesto-slider");
   if (!slider) return;
@@ -147,9 +132,7 @@ function LineText({ line }: { line: ScriptLine }) {
   );
 }
 
-// sizerLines never changes after module load, so this is built once here
-// rather than being re-mapped on every one of the ~18 frameIndex state
-// updates TerminalIntro goes through during the typing animation.
+// Built once — sizerLines never changes after module load.
 const sizerContent = sizerLines.map((line, i) => (
   <div key={i} className="whitespace-pre-wrap break-words">
     <LineText line={line} />
@@ -170,9 +153,7 @@ function Hero() {
         {SITE_DESCRIPTION}
       </h2>
 
-      {/* Skipped on mobile portrait: the intro is already tight on
-          vertical space there, and this action is one tap away in the
-          header's own GitHub link. */}
+      {/* Hidden on mobile: header already has a GitHub link. */}
       <Link
         href={GITHUB_URL}
         target="_blank"
@@ -191,13 +172,8 @@ function TerminalIntro({ active }: { active: boolean }) {
   const [frameIndex, setFrameIndex] = useState(0);
   const scrollHintRef = useRef<HTMLButtonElement>(null);
 
-  // Render the completed terminal instantly on repeat visits within the
-  // same session instead of replaying the ~4s typing animation every time.
-  // useLayoutEffect (not useEffect) so this resolves before the browser
-  // paints the empty, server-rendered terminal.
-  // Must run post-mount (sessionStorage doesn't exist during SSR); a lazy
-  // useState initializer would run on the server too and mismatch on
-  // hydration.
+  // useLayoutEffect: resolves before first paint. sessionStorage isn't
+  // available during SSR, so this can't be a lazy useState initializer.
   useLayoutEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (sessionStorage.getItem(SESSION_KEY)) setFrameIndex(lastFrame);
@@ -212,8 +188,7 @@ function TerminalIntro({ active }: { active: boolean }) {
     return () => clearTimeout(t);
   }, [frameIndex]);
 
-  // A click or keypress anywhere fast-forwards straight to the finished
-  // state instead of forcing visitors to sit through the whole animation.
+  // Click or keypress anywhere skips straight to the finished state.
   useEffect(() => {
     const skip = () => setFrameIndex(lastFrame);
     window.addEventListener("click", skip);
@@ -232,19 +207,13 @@ function TerminalIntro({ active }: { active: boolean }) {
   const isWaiting = frameIndex === lastFrame;
   const showHint = active && isWaiting;
 
-  // aria-hidden/tabIndex below make the button unreachable the instant
-  // showHint flips false, but that alone doesn't move focus off it — a
-  // keyboard user who just activated it (scrolling away, which is what
-  // flips it false) would otherwise be left with DOM focus stranded on a
-  // now aria-hidden, unfocusable element.
+  // Move focus off the button before it becomes aria-hidden/unfocusable.
   useEffect(() => {
     if (!showHint) scrollHintRef.current?.blur();
   }, [showHint]);
 
   return (
-    // md:pt-24 is intentionally looser than ManifestoSection/
-    // CallToActionSection's md:pt-20 (#552 — desktop felt dense here) —
-    // not a leftover inconsistency to "fix" back to md:pt-20.
+    // md:pt-24 is intentionally looser than the other sections' md:pt-20.
     <div className="flex flex-col items-center px-4 pt-16 sm:pt-20 md:pt-24 pb-14 sm:pb-16 md:pb-20">
       <Hero />
 
@@ -255,13 +224,8 @@ function TerminalIntro({ active }: { active: boolean }) {
           <div className="w-3 h-3 rounded-full bg-green-500"></div>
         </div>
 
-        {/* grid + the same [grid-area:1/1] on both children stacks them in
-            one cell, so the box's height comes from the invisible sizer
-            (a same-shape stand-in for the complete transcript, see
-            sizerLines above) rather than the real content — which is
-            what's growing line by line. Without this, the box visibly
-            grows throughout the whole typing animation, not just at the
-            final line. */}
+        {/* Stacked via grid so the box's height comes from the (fixed-size)
+            sizer, not the growing real content. */}
         <div className="grid py-5 sm:py-8 md:py-4 px-4 sm:px-5 md:px-6 font-mono text-green-400 text-xs sm:text-base md:text-lg bg-[#1a1a1a] text-left">
           <div aria-hidden="true" className="invisible [grid-area:1/1]">
             {sizerContent}
@@ -289,14 +253,9 @@ function TerminalIntro({ active }: { active: boolean }) {
         </div>
       </div>
 
-      {/* Fixed to the viewport, not anchored below the terminal in normal
-          flow, so it costs nothing in the top/bottom padding budget every
-          page here has to fit its content within to clear the fixed
-          header/footer. Gated on `active` (this page is the one currently
-          in view) so it doesn't stay pinned on screen once scrolled past
-          the intro — intro-only was the ask (#556). See globals.css's
-          .scroll-hint rule for why it's fixed rather than in-flow (#556,
-          #558) and why it fades out rather than snapping away (#560). */}
+      {/* Fixed, so it costs nothing in the padding budget above. Only
+          shown while `active` (this page is in view) — see globals.css's
+          .scroll-hint rule for the rest. */}
       <button
         ref={scrollHintRef}
         type="button"
@@ -325,10 +284,6 @@ function TerminalIntro({ active }: { active: boolean }) {
   );
 }
 
-// TerminalIntro never unmounts (it's the first section inside the
-// always-mounted .manifesto-slider), and its parent re-renders on every
-// IntersectionObserver update for any of the 6 manifesto sections, not
-// just this one — memo avoids redoing this component's own work
-// (including reconciling the ghost sizer) when its own `active` prop
-// hasn't actually changed.
+// Memoized: the parent re-renders on every section's scroll transition,
+// not just this one.
 export default memo(TerminalIntro);

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -49,55 +49,15 @@ body {
   overflow-x: hidden;
 }
 
-/* Reserve a stable scrollbar gutter regardless of whether a given page
-   actually needs to scroll. Without this, navigating between a short page
-   (no scrollbar) and a tall one (scrollbar present) shifts the effective
-   viewport width on platforms/browsers with classic reserved-space
-   scrollbars (common on Windows/Linux, or macOS set to always show
-   scrollbars) — visibly nudging the fixed header/nav and footer, which are
-   centered via mx-auto. */
+/* Keeps viewport width stable across pages regardless of scrollbar
+   presence, so the fixed header/footer don't visibly shift. */
 html {
   scrollbar-gutter: stable;
 }
 
-/* The manifesto's own scroll container, not the document. scroll-snap only
-   settles reliably when it's set on the actual overflow:auto/scroll box —
-   snapping the whole document (even correctly targeting the real
-   document.scrollingElement) proved flaky across browsers/trackpads in
-   practice. A plain nested overflow-y box needs no sticky positioning or
-   JS to "take over" scrolling: the browser's own scroll-chaining already
-   sends wheel/touch input to whichever scrollable element is under the
-   pointer first, only falling through to the outer page once this
-   container's own scroll is exhausted. The intro/terminal section is this
-   container's first page (native mandatory snap only responds to an
-   actual scroll gesture — it never auto-advances while stationary — so
-   reading it still can't be interrupted mid-read).
-
-   A nested scroll container isn't independently reachable by keyboard
-   scrolling unless it's focusable — see the tabIndex + aria-label on
-   ManifestoScroll's wrapper div, matching #413's own suggested fix for
-   this exact pattern.
-
-   Each page is a genuine 100dvh (Header and Footer are both fixed,
-   translucent overlays on top of it — same pattern every other route on
-   this site already uses, just with top/bottom padding sized to clear
-   them directly on each page instead of a computed height). An earlier
-   version tried to reserve chrome space via a shrunk --page-h custom
-   property sized only off the footer, on the theory that scroll-snap-
-   align: center only needed bottom clearance — wrong: centering splits
-   whatever headroom a shorter-than-100dvh page has evenly between its
-   top and bottom, so every page needed clearance from the (taller)
-   fixed header too, and never got it. That surfaced as pages overlapping
-   the header, not just the footer, only once actually measured against
-   both (#554) rather than just the one edge that had been checked before.
-
-   overflow-x: hidden is required, not cosmetic: per spec, setting only
-   overflow-y to a non-visible value promotes the other axis from visible
-   to auto too, so without this the slider silently becomes its own
-   horizontally-scrollable region. It was carrying CirclesBackground's
-   deliberately oversized decorative SVG (100rem/1600px wide, meant to be
-   clipped by body's own overflow-x: hidden) as ~600px of scrollable dead
-   space — "I can scroll right but there's nothing there" (#546). */
+/* Own scroll container (not the document) for reliable scroll-snap.
+   overflow-x: hidden is required, not cosmetic — overflow-y: auto alone
+   promotes the other axis to auto too. */
 .manifesto-slider {
   height: 100dvh;
   overflow-y: auto;
@@ -139,20 +99,8 @@ html {
   }
 }
 
-/* Homepage manifesto scroll effects: one continuous gradient painted
-   behind all manifesto sections (replacing hard per-section color cuts),
-   plus a progressive reveal driven by an IntersectionObserver + CSS
-   transition rather than animation-timeline — the latter is newer CSS that
-   can silently no-op in some browsers, which a purely decorative reveal
-   effect shouldn't risk.
-
-   The gradient lives on a ::before rather than the element's own
-   background so it can be masked to fade in from transparent over the
-   first ~30vh: that fade lets the fixed EmojiBackground canvas (sitting
-   behind the whole page) stay visible through the intro and into the first
-   bit of scroll, instead of being hard-covered the instant the manifesto
-   starts. Masking the pseudo-element leaves the section content itself
-   fully opaque/readable. */
+/* Gradient lives on ::before so it can be masked to fade in over the
+   first ~30vh without affecting section content's own opacity. */
 .manifesto-gradient {
   position: relative;
 }
@@ -214,10 +162,7 @@ html {
   scale: 1;
 }
 
-/* Parallax drift on the manifesto emoji only — decorative, continuous
-   motion at a different rate than the (steady, readable) text. Only
-   touches `translate`, so it can't fight the opacity transition above.
-   Purely an enhancement: degrades to a static emoji if unsupported. */
+/* Decorative parallax; degrades to a static emoji if unsupported. */
 @supports (animation-timeline: view()) {
   @keyframes manifesto-emoji-drift {
     from {
@@ -247,9 +192,7 @@ html {
   }
 }
 
-/* Right-side rail showing which manifesto section is currently active —
-   reuses --foreground for the active dot since it's already the exact
-   "high-contrast ink" color for both themes. */
+/* Right-side rail showing which manifesto section is active. */
 .manifesto-dots {
   position: fixed;
   right: 18px;
@@ -284,40 +227,17 @@ html {
   }
 }
 
-/* Scroll-hint chevron, fixed to the viewport and shown only on the intro
-   page (#556 — tried it on every page in #554, but once it's been used
-   once it's implicitly clear scrolling keeps working the same way on
-   every other page, so persistent everywhere wasn't wanted after all;
-   #558 tried moving it into normal document flow so it'd scroll away
-   with the page, but that traded away the fixed bottom position — asked
-   back explicitly, so it's fixed again). Both hints at and performs the
-   page-by-page snap scroll on click — see TerminalIntro.tsx.
+/* Scroll-hint chevron: fixed, shown only on the intro page. Advances the
+   snap slider on click — see TerminalIntro.tsx. Colors are Tailwind
+   classes there too (matches the Hero's "Follow on GitHub" pill), not
+   here.
 
-   .scroll-hint-hidden (#560) fades the button out via opacity rather than
-   an instant visibility cut, so leaving the intro fades it away instead
-   of snapping it out of view.
+   opacity lives in this rule's own transition, not a Tailwind utility, so
+   it can't be silently overridden by a later same-specificity rule.
 
-   Filled, not transparent: reads as a solid button against the busy
-   amber circles instead of a see-through outline. Colors match the
-   Hero's "Follow on GitHub" pill (black/white, gray-900/gray-100 hover)
-   rather than the site's --background/--foreground tokens, so the two
-   fixed on-screen controls read as the same visual language — set via
-   Tailwind utility classes in TerminalIntro.tsx, not here.
-
-   opacity lives in this same rule's transition (not a separate Tailwind
-   transition-opacity utility) so .scroll-hint-hidden's fade can't be
-   silently dropped by a same-specificity utility class overriding this
-   rule's own `transition` shorthand.
-
-   @layer components (not an unlayered rule) so this rule structurally
-   can't win a cascade fight against the Tailwind utility classes above —
-   @import "tailwindcss" declares `@layer theme, base, components,
-   utilities`, and later-declared layers always beat earlier ones
-   regardless of specificity or source order. Without this, adding so
-   much as a `background` or `border-color` here later would silently
-   and permanently override the button's Tailwind-driven dark-mode
-   colors, the same class of bug this rule already had to work around
-   once (#562). */
+   @layer components keeps Tailwind's utility classes (a higher layer)
+   always winning here, even if this rule later gains a background/color
+   property. */
 @layer components {
   .scroll-hint {
     display: flex;
@@ -328,8 +248,7 @@ html {
     border-radius: 999px;
     cursor: pointer;
     opacity: 1;
-    /* Above Footer's z-50, as a safety margin — the bottom-* offset (JSX)
-       is chosen to already clear the footer without overlapping it. */
+    /* Above Footer's z-50; bottom-* offset (JSX) already clears it. */
     z-index: 60;
     transition:
       opacity 0.15s ease-out,

--- a/web-buddy/src/app/utils.ts
+++ b/web-buddy/src/app/utils.ts
@@ -1,6 +1,4 @@
-// Client-only: window isn't defined during SSR. Every call site already
-// only calls this from an event handler or inside a useEffect, both of
-// which run client-side only.
+// window is undefined during SSR — only call this client-side.
 export function prefersReducedMotion(): boolean {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }

--- a/web-buddy/tests/manifesto-scroll-effects.spec.ts
+++ b/web-buddy/tests/manifesto-scroll-effects.spec.ts
@@ -8,8 +8,6 @@ test.describe("homepage manifesto scroll effects", () => {
 
     const gradientWrap = page.locator(".manifesto-gradient");
     await expect(gradientWrap).toBeAttached();
-    // The gradient lives on ::before (so it can be masked to fade in over
-    // the intro without masking the section content).
     const backgroundImage = await gradientWrap.evaluate(
       (el) => getComputedStyle(el, "::before").backgroundImage
     );
@@ -25,7 +23,6 @@ test.describe("homepage manifesto scroll effects", () => {
       name: "This is a hobby project",
     });
     await heading.scrollIntoViewIfNeeded();
-    // Allow the CSS transition to complete.
     await expect(heading).toHaveCSS("opacity", "1", { timeout: 2000 });
   });
 
@@ -52,8 +49,7 @@ test.describe("homepage manifesto scroll effects", () => {
     await heading.scrollIntoViewIfNeeded();
     await expect(heading).toHaveCSS("opacity", "1", { timeout: 2000 });
 
-    // Scroll far past it; its reveal must latch, so it stays opaque even
-    // while off-screen (opacity is still computable when scrolled away).
+    // Reveal must latch even while scrolled far off-screen.
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
     await page.waitForTimeout(400);
     await expect(heading).toHaveCSS("opacity", "1");
@@ -64,9 +60,6 @@ test.describe("homepage manifesto scroll effects", () => {
   }) => {
     await page.goto("/");
 
-    // The intro is a page in the slider too now (#544's own dot, so it
-    // doesn't look like "that page doesn't exist") — its dot is active
-    // immediately on load, not "nothing active until you scroll."
     const dots = page.locator(".manifesto-dot");
     await expect(dots).toHaveCount(6);
     await expect(dots.first()).toHaveClass(/active/, { timeout: 2000 });
@@ -88,9 +81,6 @@ test.describe("homepage manifesto scroll effects", () => {
     await page.waitForTimeout(300);
     await page.mouse.click(200, 700);
 
-    // Exactly one, ever — tried one per page in #554, but once it's been
-    // used it's implicitly clear scrolling keeps working the same way
-    // elsewhere, so persistent everywhere wasn't wanted after all.
     const hint = page.getByRole("button", { name: "Scroll to the next page" });
     await expect(hint).toHaveCount(1);
     await expect(hint).toBeVisible();
@@ -103,10 +93,7 @@ test.describe("homepage manifesto scroll effects", () => {
     await hint.click();
     await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
 
-    // No longer the active page: still fixed and still the only instance,
-    // but hidden via an opacity fade (#558) rather than an instant
-    // visibility cut. aria-hidden now correctly drops it out of the
-    // accessibility tree, so it has to be found by test id, not role.
+    // aria-hidden now, so found by test id rather than role.
     const hiddenHint = page.getByTestId("scroll-hint");
     await expect(hiddenHint).toHaveCSS("opacity", "0", { timeout: 2000 });
     await expect(hiddenHint).toHaveAttribute("aria-hidden", "true");
@@ -128,8 +115,6 @@ test.describe("homepage manifesto scroll effects", () => {
     const dots = page.locator(".manifesto-dot");
     await expect(dots.nth(1)).toHaveClass(/active/, { timeout: 3000 });
 
-    // The button is now aria-hidden/tabIndex=-1; DOM focus must have moved
-    // off it rather than being left stranded on a now-inaccessible element.
     const hiddenHint = page.getByTestId("scroll-hint");
     await expect(hiddenHint).toHaveAttribute("aria-hidden", "true");
     await expect(hiddenHint).not.toBeFocused();

--- a/web-buddy/tests/scroll-snap.spec.ts
+++ b/web-buddy/tests/scroll-snap.spec.ts
@@ -1,14 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-// The manifesto sections live in their own overflow-y:auto scroll
-// container (.manifesto-slider) with native CSS scroll-snap — see
-// globals.css for why this (not a document-level snap, not a JS-driven
-// ease) is the version that's actually reliable. Real wheel/trackpad
-// input isn't something Playwright's synthetic events can reliably
-// exercise in headless Chromium (a known CDP limitation, not a sign the
-// CSS is wrong — see the PR description), so this asserts the CSS is
-// correctly declared plus the keyboard-driven settle, which *is*
-// deterministic and directly observable.
+// Real wheel/trackpad input isn't reliable in headless Chromium, so this
+// asserts the CSS is correctly declared plus the keyboard-driven settle.
 test.describe("homepage manifesto scroll snap", () => {
   test("the intro is the snap container's first page, ideas/CTA follow", async ({
     page,
@@ -64,25 +57,8 @@ test.describe("homepage manifesto scroll snap", () => {
     );
   });
 
-  // Header and Footer are both fixed, translucent overlays on every page
-  // here (min-h-dvh, same as everywhere else on the site) — each page's
-  // own pt-*/pb-* padding is what has to actually clear them, not the
-  // section's own box (which deliberately spans the full viewport, so
-  // checking *that* against the footer/header is always trivially near-
-  // zero regardless of whether real content is obscured — checked the
-  // wrong element early in #554 and it silently passed for that reason).
-  //
-  // 360px (Moto G4/Galaxy S/Pixel-class — Chrome DevTools' own small-phone
-  // default) is the realistic floor, not 320px: that's specifically the
-  // 2016 iPhone SE 1st-gen, long discontinued, and SITE_DESCRIPTION's
-  // fixed length makes an exact fit infeasible there without shrinking
-  // spacing at every more common size to accommodate a legacy outlier.
-  //
-  // 1280x720 specifically: Playwright's own default chromium project
-  // viewport. #544's scroll-hint arrow silently broke this exact size
-  // (never manually checked, since 1280x800 was — a reasonable-looking
-  // choice that happened to have just enough extra height to hide the
-  // gap) until the click-to-advance test below started failing.
+  // Checks actual content (h1, .scroll-hint), not the section's own box —
+  // that always spans the full viewport regardless of content fit.
   for (const viewport of [
     { width: 360, height: 740, label: "small mobile" },
     { width: 375, height: 812, label: "mobile" },
@@ -114,11 +90,6 @@ test.describe("homepage manifesto scroll snap", () => {
     });
   }
 
-  // Only overflow-y was set, and per spec that silently promotes
-  // overflow-x from visible to auto too — turning any oversized
-  // descendant (CirclesBackground's deliberately 100rem-wide decorative
-  // SVG, previously safely clipped by body's own overflow-x: hidden) into
-  // real horizontally-scrollable dead space (#546).
   test("the slider can't be scrolled horizontally", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");

--- a/web-buddy/tests/terminal-skip.spec.ts
+++ b/web-buddy/tests/terminal-skip.spec.ts
@@ -7,8 +7,6 @@ test.describe("terminal intro skip and session persistence", () => {
   }) => {
     await page.goto("/");
 
-    // Click almost immediately, well before the animation would naturally
-    // finish (measured at ~5s in the issue).
     await page.waitForTimeout(200);
     await page.mouse.click(10, 10);
 
@@ -41,8 +39,6 @@ test.describe("terminal intro skip and session persistence", () => {
     await page.goto("/tools");
     await page.goto("/");
 
-    // On the repeat visit the completed terminal renders immediately,
-    // without waiting for the typing animation to play out again.
     await expect(
       terminalOutputText(page, "Scroll down to continue...")
     ).toBeVisible({ timeout: 500 });


### PR DESCRIPTION
Closes #598.

## Summary
The scroll-hint/intro feature accumulated heavy comment bloat across many small PRs this session — multi-paragraph historical narration ("an earlier version tried X — wrong: ...") and issue-number references (#413, #544, #546, #554, #556, #558, #560, #562). Trimmed hard across `globals.css`, `TerminalIntro.tsx`, `ManifestoScroll.tsx`, `utils.ts`, and the touched test files.

Kept only short, genuinely non-obvious "why" notes; dropped history (git log's job) and anything the code already says via naming. Net: -240/+53 lines.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (verified `.scroll-hint`/`.manifesto-slider` present in built CSS, comment/brace counts balanced)
- [x] Full Playwright suite (`--workers=1`): 168/168 passed