### PR TITLE
Install Firefox in the Pages deploy workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -39,7 +39,11 @@ jobs:
       # ci.yml's push-triggered run — which races this workflow — passed.
       # Playwright's webServer config (playwright.config.ts) starts and
       # waits for `serve` itself.
-      - run: npx playwright install --with-deps chromium
+      # Keep this browser list in step with playwright.config.ts's projects
+      # and with ci.yml — a project whose browser isn't installed here fails
+      # the whole deploy, and this workflow only runs on push to main, so a
+      # green PR won't catch the mismatch.
+      - run: npx playwright install --with-deps chromium firefox
       - run: npx playwright test
 
       - run: touch out/.nojekyll


### PR DESCRIPTION
## Problem
#605 added a Firefox Playwright project and updated `ci.yml`, but `pages-deploy.yml` runs its **own** `playwright install` — still Chromium-only. So every Firefox test failed there with:

```
Error: browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/firefox-1532/firefox/firefox
```

254 passed, ~99 failed, deploy exited 1. My miss in #605.

## Why PR CI didn't catch it
`pages-deploy.yml` only runs on push to main, so it never executed while #605 was a PR. The failure surfaced only after merge.

## Fix
Install `chromium firefox` in the deploy workflow, with a comment tying the browser list to `playwright.config.ts` and `ci.yml`. Grepped the workflow dir to confirm these two are the only places Playwright runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)