### PR TITLE
Fix premature scroll on tools/about pages

### DIFF
--- a/web-buddy/src/app/about/page.tsx
+++ b/web-buddy/src/app/about/page.tsx
@@ -123,7 +123,7 @@ export default function AboutPage() {
     <>
       <JsonLd id="jsonld-about" data={jsonLd} />
       <Header />
-      <main className="min-h-screen pt-20 md:pt-32 pb-28 px-4 md:px-6 max-w-5xl mx-auto">
+      <main className="relative min-h-screen pt-20 md:pt-32 pb-16 px-4 md:px-6 max-w-5xl mx-auto">
         <CirclesBackground variant="about" />
         <h1 className="text-center relative z-10 text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
           About / Impressum

--- a/web-buddy/src/app/components/CirclesBackground.tsx
+++ b/web-buddy/src/app/components/CirclesBackground.tsx
@@ -47,7 +47,9 @@ export default function CirclesBackground({
   variant = "tools",
 }: CirclesBackgroundProps) {
   return (
-    <div className="w-full relative -z-10 pointer-events-none">
+    // Clips to the positioned parent's own bounds so the oversized
+    // decorative svg below can't inflate the page's scroll height.
+    <div className="absolute inset-0 -z-10 overflow-hidden pointer-events-none">
       <svg
         className="absolute left-1/2 -translate-x-1/2 w-[100rem] h-[80rem] opacity-100"
         style={{ top: "-15rem" }}

--- a/web-buddy/src/app/components/ManifestoScroll.tsx
+++ b/web-buddy/src/app/components/ManifestoScroll.tsx
@@ -160,7 +160,7 @@ export default function ManifestoScroll() {
         tabIndex={0}
         aria-label="Manifesto: what nobuddy.org is about"
       >
-        <section className="min-h-dvh snap-center" ref={register(0)}>
+        <section className="relative min-h-dvh snap-center" ref={register(0)}>
           <CirclesBackground variant="home" />
           <TerminalIntro active={active[0]} />
         </section>

--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -43,7 +43,7 @@ export default function ToolGrid() {
         <br />
         <section
           id="tools"
-          className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 sm:px-6 mb-28"
+          className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 sm:px-6 mb-16"
         >
           {paginatedTools.map((tool, index) => {
             const isReady = tool.status === "ready";

--- a/web-buddy/src/app/tools/page.tsx
+++ b/web-buddy/src/app/tools/page.tsx
@@ -43,7 +43,7 @@ export default function HomePage() {
     <>
       <JsonLd id="jsonld-tools" data={jsonLd} />
       <Header />
-      <main>
+      <main className="relative">
         <CirclesBackground variant="tools" />
         <ToolGrid />
       </main>


### PR DESCRIPTION
## Summary
- The decorative `CirclesBackground` SVG (1280px tall) was absolutely positioned but never clipped, silently extending the scrollable area of the `/tools` and `/about` pages past their real content — worst on `/about`, which had almost no content but still scrolled ~270px past the footer.
- It only worked correctly on the home hero because that section already clips overflow for its scroll-snap behavior.
- Also trimmed the footer-clearance padding (`mb-28`/`pb-28`, 112px) on both pages down to 64px, matching the footer's actual ~61px height, removing dead scroll space.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified via headless Playwright: `/about` scrollHeight now matches viewport exactly (was 268px taller); `/tools` scrollHeight dropped from 1120px to 1072px
- [x] Screenshotted home, tools, and about pages to confirm the decorative circles still render correctly and the fixed footer doesn't overlap content

🤖 Generated with [Claude Code](https://claude.com/claude-code)