### PR TITLE
Soften mobile hero shadow, align heading sizes across pages

### DIFF
--- a/web-buddy/src/app/about/page.tsx
+++ b/web-buddy/src/app/about/page.tsx
@@ -125,7 +125,7 @@ export default function AboutPage() {
       <Header />
       <main className="relative min-h-screen pt-20 md:pt-32 pb-16 px-4 md:px-6 max-w-5xl mx-auto">
         <CirclesBackground variant="about" />
-        <h1 className="text-center relative z-10 text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+        <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
           About / Impressum
         </h1>
         <br />

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -145,11 +145,11 @@ function Hero() {
       className="relative pb-3 sm:pb-5 md:pb-6 max-w-4xl mx-auto px-4 md:px-6 text-center"
       aria-label="Introduction section"
     >
-      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-3 text-black dark:text-white dark:[text-shadow:0_0_2px_rgba(0,0,0,0.95),0_0_6px_rgba(0,0,0,0.9),0_0_16px_rgba(0,0,0,0.8),0_2px_6px_rgba(0,0,0,0.9)]">
+      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-3 text-black dark:text-white dark:[text-shadow:0_0_2px_rgba(0,0,0,0.6),0_0_8px_rgba(0,0,0,0.5)] sm:dark:[text-shadow:0_0_2px_rgba(0,0,0,0.95),0_0_6px_rgba(0,0,0,0.9),0_0_16px_rgba(0,0,0,0.8),0_2px_6px_rgba(0,0,0,0.9)]">
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-3 dark:[text-shadow:0_0_1px_rgba(0,0,0,1),0_0_3px_rgba(0,0,0,0.95),0_0_9px_rgba(0,0,0,0.85)]">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-3 dark:[text-shadow:0_0_2px_rgba(0,0,0,0.6),0_0_6px_rgba(0,0,0,0.45)] sm:dark:[text-shadow:0_0_1px_rgba(0,0,0,1),0_0_3px_rgba(0,0,0,0.95),0_0_9px_rgba(0,0,0,0.85)]">
         {SITE_DESCRIPTION}
       </h2>
 

--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -35,10 +35,10 @@ export default function ToolGrid() {
   return (
     <>
       <div className="relative pt-20 md:pt-32 min-h-[60rem]">
-        <h1 className="text-center relative z-10 text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+        <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
           The Buddy Compendium
         </h1>
-        <h2 className="text-center relative z-10 max-w-2xl mx-auto text-lg sm:text-xl text-neutral-700 dark:text-neutral-200 mb-4 md:mb-8">
+        <h2 className="text-center relative z-10 max-w-2xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-4 md:mb-8">
           Blending quirky charm with real-world usefulness for {"'everybuddy'"}
         </h2>
         <br />


### PR DESCRIPTION
## Summary
- The dark-mode text-shadow on the homepage hero (added in #638) was too strong on mobile. It's now subtler by default and only steps up to the heavier outline at `sm:` and above.
- `/tools` and `/about` had drifted from the homepage's responsive heading scale (they skipped the mobile step, e.g. `text-5xl md:text-6xl` instead of `text-3xl sm:text-5xl md:text-6xl`), making their h1/h2 noticeably larger on mobile than the homepage. Aligned both to the homepage's sizes.

## Test plan
- [x] `tsc --noEmit`, `eslint` pass
- [x] Full Playwright suite passes locally (352 passed)
- [x] Verified via screenshots at mobile viewport, light + dark, on `/`, `/tools`, `/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)