### PR TITLE
Darken mobile circles instead of text-shadow, fix about desktop clipping

### DIFF
--- a/web-buddy/src/app/about/page.tsx
+++ b/web-buddy/src/app/about/page.tsx
@@ -123,16 +123,18 @@ export default function AboutPage() {
     <>
       <JsonLd id="jsonld-about" data={jsonLd} />
       <Header />
-      <main className="relative min-h-screen pt-20 md:pt-32 pb-16 px-4 md:px-6 max-w-5xl mx-auto">
+      <main className="relative min-h-screen pt-20 md:pt-32 pb-16 px-4 md:px-6">
         <CirclesBackground variant="about" />
-        <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
-          About / Impressum
-        </h1>
-        <br />
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-8 text-sm leading-relaxed">
-          <EnglishSection />
-          <GermanSection />
-        </section>
+        <div className="max-w-5xl mx-auto">
+          <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+            About / Impressum
+          </h1>
+          <br />
+          <section className="grid grid-cols-1 md:grid-cols-2 gap-8 text-sm leading-relaxed">
+            <EnglishSection />
+            <GermanSection />
+          </section>
+        </div>
       </main>
       <Footer />
     </>

--- a/web-buddy/src/app/components/CirclesBackground.tsx
+++ b/web-buddy/src/app/components/CirclesBackground.tsx
@@ -5,12 +5,17 @@
 // strings (not built from interpolated hex values) so Tailwind's static
 // scanner can still discover and generate them — it can't see through
 // runtime string concatenation.
+//
+// Dark mode uses a darker, muted shade below `sm:` — on mobile the circles
+// fill most of the viewport behind hero text, and the bright desktop shade
+// doesn't leave enough contrast against white text. From `sm:` up, circles
+// are smaller relative to the viewport, so the original bright shade returns.
 const PALETTE_CLASSES = [
-  "fill-[#FFF7DC] dark:fill-[#FCD34D]",
-  "fill-[#FFE9B8] dark:fill-[#FBBF24]",
-  "fill-[#FFD285] dark:fill-[#F59E0B]",
-  "fill-[#F6B73C] dark:fill-[#D97706]",
-  "fill-[#E09E27] dark:fill-[#B45309]",
+  "fill-[#FFF7DC] dark:fill-[#92400E] sm:dark:fill-[#FCD34D]",
+  "fill-[#FFE9B8] dark:fill-[#78350F] sm:dark:fill-[#FBBF24]",
+  "fill-[#FFD285] dark:fill-[#451A03] sm:dark:fill-[#F59E0B]",
+  "fill-[#F6B73C] dark:fill-[#451A03] sm:dark:fill-[#D97706]",
+  "fill-[#E09E27] dark:fill-[#2E1002] sm:dark:fill-[#B45309]",
 ];
 
 type Circle = { cx: number; cy: number; r: number };

--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -145,11 +145,11 @@ function Hero() {
       className="relative pb-3 sm:pb-5 md:pb-6 max-w-4xl mx-auto px-4 md:px-6 text-center"
       aria-label="Introduction section"
     >
-      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-3 text-black dark:text-white dark:[text-shadow:0_0_2px_rgba(0,0,0,0.6),0_0_8px_rgba(0,0,0,0.5)] sm:dark:[text-shadow:0_0_2px_rgba(0,0,0,0.95),0_0_6px_rgba(0,0,0,0.9),0_0_16px_rgba(0,0,0,0.8),0_2px_6px_rgba(0,0,0,0.9)]">
+      <h1 className="relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-2 sm:mb-4 md:mb-3 text-black dark:text-white">
         {SITE_NAME}
       </h1>
 
-      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-3 dark:[text-shadow:0_0_2px_rgba(0,0,0,0.6),0_0_6px_rgba(0,0,0,0.45)] sm:dark:[text-shadow:0_0_1px_rgba(0,0,0,1),0_0_3px_rgba(0,0,0,0.95),0_0_9px_rgba(0,0,0,0.85)]">
+      <h2 className="block relative z-10 max-w-3xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-800 dark:text-neutral-100 mb-4 sm:mb-6 md:mb-3">
         {SITE_DESCRIPTION}
       </h2>
 

--- a/web-buddy/tests/circles-background.spec.ts
+++ b/web-buddy/tests/circles-background.spec.ts
@@ -5,11 +5,11 @@ import { test, expect } from "@playwright/test";
 // three repeated switch branches into shared palette + per-variant position
 // data — can't silently drift the visuals it replaced.
 const PALETTE_CLASSES = [
-  "fill-[#FFF7DC] dark:fill-[#FCD34D]",
-  "fill-[#FFE9B8] dark:fill-[#FBBF24]",
-  "fill-[#FFD285] dark:fill-[#F59E0B]",
-  "fill-[#F6B73C] dark:fill-[#D97706]",
-  "fill-[#E09E27] dark:fill-[#B45309]",
+  "fill-[#FFF7DC] dark:fill-[#92400E] sm:dark:fill-[#FCD34D]",
+  "fill-[#FFE9B8] dark:fill-[#78350F] sm:dark:fill-[#FBBF24]",
+  "fill-[#FFD285] dark:fill-[#451A03] sm:dark:fill-[#F59E0B]",
+  "fill-[#F6B73C] dark:fill-[#451A03] sm:dark:fill-[#D97706]",
+  "fill-[#E09E27] dark:fill-[#2E1002] sm:dark:fill-[#B45309]",
 ];
 
 const expectations = [


### PR DESCRIPTION
## Summary
- Reverts the dark-mode text-shadow from #640 (too heavy, and applied at every breakpoint when only mobile needed it).
- Fixes the same mobile contrast problem by darkening the decorative circles below `sm:` in dark mode instead, restoring the original bright shade at `sm:` and up. Since `CirclesBackground` is shared, this also fixes the identical contrast issue on `/tools` and `/about` for free.
- Fixes `/about` on desktop: its `<main>` had `max-w-5xl` directly on it, which clipped the circles (positioned `absolute inset-0` in that same element) to the narrow content column instead of the viewport, cutting them off on every side. Moved the `max-w-5xl` constraint to an inner wrapper around just the content, matching how `/` and `/tools` are structured.

## Test plan
- [x] `tsc --noEmit`, `eslint` pass
- [x] Full Playwright suite passes locally (352 passed), including updated `circles-background.spec.ts` palette assertions
- [x] Verified via screenshots at mobile + desktop, light + dark, on `/`, `/tools`, `/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)