### PR TITLE
Widen circle color steps, align /tools heading width

### DIFF
--- a/web-buddy/src/app/components/CirclesBackground.tsx
+++ b/web-buddy/src/app/components/CirclesBackground.tsx
@@ -6,16 +6,15 @@
 // scanner can still discover and generate them — it can't see through
 // runtime string concatenation.
 //
-// Dark mode uses a darker, muted shade below `sm:` — on mobile the circles
-// fill most of the viewport behind hero text, and the bright desktop shade
-// doesn't leave enough contrast against white text. From `sm:` up, circles
-// are smaller relative to the viewport, so the original bright shade returns.
+// The dark-mode shade is deliberately darker/muted than the original bright
+// amber: on mobile the circles fill most of the viewport behind hero text,
+// and the bright shade didn't leave enough contrast against white text.
 const PALETTE_CLASSES = [
-  "fill-[#FFF7DC] dark:fill-[#92400E] sm:dark:fill-[#FCD34D]",
-  "fill-[#FFE9B8] dark:fill-[#78350F] sm:dark:fill-[#FBBF24]",
-  "fill-[#FFD285] dark:fill-[#451A03] sm:dark:fill-[#F59E0B]",
-  "fill-[#F6B73C] dark:fill-[#451A03] sm:dark:fill-[#D97706]",
-  "fill-[#E09E27] dark:fill-[#2E1002] sm:dark:fill-[#B45309]",
+  "fill-[#FFF7DC] dark:fill-[#E3780D]",
+  "fill-[#FFE9B8] dark:fill-[#C1660B]",
+  "fill-[#FFD285] dark:fill-[#A4570A]",
+  "fill-[#F6B73C] dark:fill-[#874708]",
+  "fill-[#E09E27] dark:fill-[#6F3B06]",
 ];
 
 type Circle = { cx: number; cy: number; r: number };

--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -35,12 +35,14 @@ export default function ToolGrid() {
   return (
     <>
       <div className="relative pt-20 md:pt-32 min-h-[60rem]">
-        <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
-          The Buddy Compendium
-        </h1>
-        <h2 className="text-center relative z-10 max-w-2xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-4 md:mb-8">
-          Blending quirky charm with real-world usefulness for {"'everybuddy'"}
-        </h2>
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          <h1 className="text-center relative z-10 text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
+            The Buddy Compendium
+          </h1>
+          <h2 className="text-center relative z-10 max-w-2xl mx-auto text-sm sm:text-lg md:text-xl text-neutral-700 dark:text-neutral-200 mb-4 md:mb-8">
+            Blending quirky charm with real-world usefulness for {"'everybuddy'"}
+          </h2>
+        </div>
         <br />
         <section
           id="tools"

--- a/web-buddy/tests/circles-background.spec.ts
+++ b/web-buddy/tests/circles-background.spec.ts
@@ -5,11 +5,11 @@ import { test, expect } from "@playwright/test";
 // three repeated switch branches into shared palette + per-variant position
 // data — can't silently drift the visuals it replaced.
 const PALETTE_CLASSES = [
-  "fill-[#FFF7DC] dark:fill-[#92400E] sm:dark:fill-[#FCD34D]",
-  "fill-[#FFE9B8] dark:fill-[#78350F] sm:dark:fill-[#FBBF24]",
-  "fill-[#FFD285] dark:fill-[#451A03] sm:dark:fill-[#F59E0B]",
-  "fill-[#F6B73C] dark:fill-[#451A03] sm:dark:fill-[#D97706]",
-  "fill-[#E09E27] dark:fill-[#2E1002] sm:dark:fill-[#B45309]",
+  "fill-[#FFF7DC] dark:fill-[#E3780D]",
+  "fill-[#FFE9B8] dark:fill-[#C1660B]",
+  "fill-[#FFD285] dark:fill-[#A4570A]",
+  "fill-[#F6B73C] dark:fill-[#874708]",
+  "fill-[#E09E27] dark:fill-[#6F3B06]",
 ];
 
 const expectations = [


### PR DESCRIPTION
## Summary
- The dark-mode circle palette (from #641) had two pairs of identical colors, so adjacent circles visually blended together. Same rust-orange hue family, but now five clearly distinct lightness steps.
- Wraps the `/tools` heading + subtitle in the same `max-w-6xl px-4 sm:px-6` container as the card grid below, so they align to the same width instead of the heading spanning the full viewport.

## Test plan
- [x] `tsc --noEmit`, `eslint` pass
- [x] Full Playwright suite passes locally (352 passed), including updated `circles-background.spec.ts` palette assertions
- [x] Verified live via local dev server across several palette iterations before landing on this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)