### PR TITLE
Fix nanoid/brace-expansion advisories, actually fix circle crop on tall viewports

### DIFF
--- a/web-buddy/package-lock.json
+++ b/web-buddy/package-lock.json
@@ -5627,9 +5627,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/web-buddy/package-lock.json
+++ b/web-buddy/package-lock.json
@@ -2567,9 +2567,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web-buddy/package.json
+++ b/web-buddy/package.json
@@ -36,7 +36,7 @@
     "typescript": "6.0.3"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "nanoid": "^3.3.18",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3"

--- a/web-buddy/package.json
+++ b/web-buddy/package.json
@@ -37,6 +37,7 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.8",
+    "nanoid": "^3.3.18",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3"
   }

--- a/web-buddy/src/app/components/CirclesBackground.tsx
+++ b/web-buddy/src/app/components/CirclesBackground.tsx
@@ -54,6 +54,7 @@ export default function CirclesBackground({
         className="absolute left-1/2 -translate-x-1/2 w-[100rem] h-[150dvh] opacity-100"
         style={{ top: "-15rem" }}
         viewBox="0 0 528 560"
+        preserveAspectRatio="xMidYMid slice"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"


### PR DESCRIPTION
## Summary
- Pin `nanoid` override to `^3.3.18`, fixing Dependabot alert #43 (GHSA-2v37-7h3g-55p8, DoS via zero-size custom generators), transitive via `postcss`.
- Bump `brace-expansion` override to `^5.0.9`, fixing GHSA-rgw5-rvv9-x895 (DoS bypass of an earlier mitigation) found via `npm audit`.
- `image-size`'s two DoS advisories (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq) have no fixed release yet (2.0.2 is latest) — left unpinned.
- Actually fix the decorative circle crop on tall viewports (#643 only masked it): the SVG used the default `xMidYMid meet`, which scales to *fit inside* its box width-first — since the box width is a fixed `100rem` but height is `dvh`-based, the rendered artwork's height was capped regardless of how tall the box was declared, so it fell short of the section bottom and got clipped with a flat edge on tall viewports. Switched to `xMidYMid slice`, which scales to always cover the box (overflowing horizontally instead, which is invisible/clipped off-screen).

## Test plan
- [x] `npm run lint`
- [x] Playwright screenshots in Chromium and Firefox at 1280×1400, 1280×2000, 390×664, 390×844 (before/after scroll) — circles reach the section bottom with a smooth curve, no flat crop
- [x] Verified `/tools` and `/about` (which share `CirclesBackground`) render correctly, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)