### PR TITLE
Unify body/page-band background, kill forced bottom whitespace

### DIFF
--- a/web-buddy/src/app/about/page.tsx
+++ b/web-buddy/src/app/about/page.tsx
@@ -157,7 +157,7 @@ export default function AboutPage() {
     <>
       <JsonLd id="jsonld-about" data={jsonLd} />
       <Header />
-      <main className="relative min-h-screen page-band">
+      <main className="relative">
         <div className="pt-20 md:pt-28 px-4 md:px-6">
           <h1
             data-testid="about-heading"
@@ -169,7 +169,7 @@ export default function AboutPage() {
             </span>
           </h1>
         </div>
-        <div className="max-w-5xl mx-auto px-4 md:px-6 pt-10 md:pt-12 pb-16">
+        <div className="max-w-5xl mx-auto px-4 md:px-6 pt-10 md:pt-12 pb-6">
           <section className="grid grid-cols-1 md:grid-cols-2 gap-8 text-sm leading-relaxed">
             <EnglishSection />
             <GermanSection />

--- a/web-buddy/src/app/components/ToolGrid.tsx
+++ b/web-buddy/src/app/components/ToolGrid.tsx
@@ -57,10 +57,10 @@ export default function ToolGrid() {
           </h2>
         </div>
       </div>
-      <div className="relative min-h-[40rem] pt-4 md:pt-6">
+      <div className="relative pt-4 md:pt-6 pb-6">
         <section
           id="tools"
-          className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 sm:px-6 mb-16"
+          className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 sm:px-6"
         >
           {paginatedTools.map((tool, index) => {
             const isReady = tool.status === "ready";
@@ -193,14 +193,14 @@ function Pagination({
   return (
     <nav
       aria-label="Tools pagination"
-      className="w-fit mx-auto mt-0 rounded-2xl p-4 border bg-white/60 dark:bg-black/60 border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-[0_2px_8px_rgba(255,255,255,0.05)] backdrop-blur-sm mb-0 md:mb-10"
+      className="w-fit mx-auto rounded-2xl p-4 border bg-white/60 dark:bg-black/60 border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-[0_2px_8px_rgba(255,255,255,0.05)] backdrop-blur-sm"
     >
       <div className="flex justify-center gap-2 items-center text-sm">
         <button
           onClick={() => onPageChange(Math.max(1, currentPage - 1))}
           disabled={currentPage === 1}
           aria-label="Previous page"
-          className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40"
+          className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40 disabled:pointer-events-none"
         >
           ◀
         </button>
@@ -223,7 +223,7 @@ function Pagination({
           onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
           disabled={currentPage === totalPages}
           aria-label="Next page"
-          className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40"
+          className="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40 disabled:pointer-events-none"
         >
           ▶
         </button>

--- a/web-buddy/src/app/components/ToolPageShell.tsx
+++ b/web-buddy/src/app/components/ToolPageShell.tsx
@@ -8,7 +8,7 @@ export default function ToolPageShell({
   children: React.ReactNode;
 }) {
   return (
-    <main className="min-h-screen pt-16 md:pt-20 pb-28 px-4 sm:px-6 page-band">
+    <main className="pt-16 md:pt-20 pb-6 px-4 sm:px-6">
       <div className="max-w-5xl mx-auto rounded-2xl p-6 sm:p-10 border bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 shadow-xl">
         <h1
           data-testid="tool-heading"

--- a/web-buddy/src/app/globals.css
+++ b/web-buddy/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #faf3e7;
   --foreground: #171717;
   /* Wordmark accent only (issue #625) — deliberately not reused for
      buttons/links, since text at this size needs 4.5:1 while UI chrome
@@ -18,7 +18,6 @@
     #ecfccb 100%
   );
   --manifesto-dot: #d4d4d8;
-  --page-band-bg: #faf3e7;
 }
 
 @theme inline {
@@ -33,7 +32,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #1e1e1e;
     --foreground: #ededed;
     /* Lighter than the light-theme shade — #ad5725 falls under 4.5:1 on
        this theme's near-black surfaces. */
@@ -49,7 +48,6 @@
       #365314 100%
     );
     --manifesto-dot: #3f3f46;
-    --page-band-bg: #1e1e1e;
   }
 }
 
@@ -126,10 +124,6 @@ html {
   background-image: var(--manifesto-gradient);
   background-size: 100% 100%;
   background-repeat: no-repeat;
-}
-
-.page-band {
-  background-color: var(--page-band-bg);
 }
 
 .cmd-cursor {

--- a/web-buddy/src/app/not-found.tsx
+++ b/web-buddy/src/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
   return (
     <>
       <Header />
-      <main className="min-h-screen flex flex-col items-center justify-center text-center px-4 md:px-6 pt-20 md:pt-32 pb-28">
+      <main className="min-h-screen flex flex-col items-center justify-center text-center px-4 md:px-6 pt-20 md:pt-32 pb-16">
         <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight leading-tight mb-4 md:mb-6 text-black dark:text-white">
           404
         </h1>

--- a/web-buddy/src/app/tools/page.tsx
+++ b/web-buddy/src/app/tools/page.tsx
@@ -41,7 +41,7 @@ export default function HomePage() {
     <>
       <JsonLd id="jsonld-tools" data={jsonLd} />
       <Header />
-      <main className="relative min-h-screen page-band">
+      <main className="relative">
         <ToolGrid />
       </main>
     </>


### PR DESCRIPTION
## Summary
- `--background` (body's own color) and `--page-band-bg` were two separate values that had to stay coverage-matched everywhere `<main>` didn't fully fill the page — every mismatch showed up as a visible color seam at the bottom of `/tools`, `/about`, and tool-detail pages.
- Merged them into one value per theme; removed the now-redundant `--page-band-bg` variable and `.page-band` class.
- Dropped the `min-height` floors (`main`'s `min-h-screen`, the tools grid's `min-h-[40rem]`) that mainly existed to guarantee that coverage — pages are now exactly as tall as their content, in one color, with no seam possible regardless of viewport height.
- Trimmed leftover bottom padding (`pb-28`, `pb-16`, a stray `md:mb-10` on the pagination nav) that was sized to clear the old fixed footer, which no longer exists on these pages.
- Pagination prev/next buttons kept showing a hover reaction while `disabled` (native `disabled` blocks clicks but not `:hover`) even though clicking already did nothing — added `disabled:pointer-events-none`.

## Test plan
- [x] `npx eslint .` — clean
- [x] `npm run build` — compiles, all routes static-generate
- [x] `npx playwright test` — full suite green (344 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)