### PR TITLE
Fix mobile screenshot row order on tool detail pages

### DIFF
--- a/web-buddy/src/app/components/ToolScreenshots.tsx
+++ b/web-buddy/src/app/components/ToolScreenshots.tsx
@@ -46,21 +46,21 @@ function ScreenshotRow({
           alt=""
           width={300}
           height={200}
-          className="rounded-xl shadow-md w-full md:w-1/2"
+          className="order-2 md:order-none rounded-xl shadow-md w-full md:w-1/2"
         />
       ) : (
         <AnimatedClip
           src={`${imageDir}/${src}.mp4`}
           poster={`${imageDir}/${src}-poster.jpg`}
           label=""
-          className="rounded-xl shadow-md w-full md:w-1/2"
+          className="order-2 md:order-none rounded-xl shadow-md w-full md:w-1/2"
         />
       )}
-      <div className="text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
-        <h3 className="text-xl font-semibold mb-2 text-black dark:text-white">
+      <div className="contents md:block text-gray-700 dark:text-gray-300 text-base leading-relaxed md:w-1/2">
+        <h3 className="order-1 md:order-none text-xl font-semibold mb-2 text-black dark:text-white">
           {alt}
         </h3>
-        <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+        <p className="order-3 md:order-none text-sm leading-relaxed text-gray-700 dark:text-gray-300">
           {text}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- On mobile, each screenshot row in `ToolScreenshots` rendered as image → headline → text, which reads oddly since the caption appeared after the image.
- Reordered to headline → image → text on mobile using flex `order` utilities (`contents` on the text wrapper so the heading and paragraph become independent flex items that can be reordered around the image).
- Desktop's side-by-side, alternating layout is unchanged (`md:order-none` resets the mobile ordering).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] Verified visually with Playwright screenshots at 390px (mobile) and 1280px (desktop) on `/tools/bikebuddy`, confirming the new mobile order and unchanged desktop layout

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWRLJK5yBpDQ6Kuq31vGFm)_