### PR TITLE
Start terminal intro's leading command with nobuddy init

### DIFF
--- a/web-buddy/src/app/components/TerminalIntro.tsx
+++ b/web-buddy/src/app/components/TerminalIntro.tsx
@@ -73,7 +73,7 @@ function buildFrames(): Frame[] {
     frames.push({ lines: [...last(), line], delay });
   const pause = (delay: number) => frames.push({ lines: last(), delay });
 
-  push({ role: "cmd", text: "initialize --buddyverse" }, 700);
+  push({ role: "cmd", text: "nobuddy init" }, 700);
   push({ role: "echo", text: msg1 }, 500);
   push({ role: "echo", text: `${loadingMessage} ${loadingSteps[0]}` }, 0);
   for (let i = 1; i < loadingSteps.length; i++) {
@@ -98,7 +98,7 @@ const lastFrame = frames.length - 1;
 // Same shape as frames[lastFrame].lines, with maxWidthPlaceholder instead
 // of the random text.
 const sizerLines: ScriptLine[] = [
-  { role: "cmd", text: "initialize --buddyverse" },
+  { role: "cmd", text: "nobuddy init" },
   { role: "echo", text: maxWidthPlaceholder },
   {
     role: "echo",


### PR DESCRIPTION
## Summary
- The homepage's animated terminal (`TerminalIntro`) typed `initialize --buddyverse` as its first command, while the static hero heading right above it reads `$ nobuddy init`.
- The animation's leading command now types `nobuddy init` too, so the animated shell and the static heading agree.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npx playwright test tests/homepage.spec.ts --project=chromium` (5 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G15LmG9htBAWtGW1qLwWNK)_